### PR TITLE
[Amavis] New cron to be launched between 10am and 5pm

### DIFF
--- a/amavis/conf/cron/agentj-amavis
+++ b/amavis/conf/cron/agentj-amavis
@@ -1,2 +1,1 @@
-0 14 * * * /usr/bin/freshclam --log=/var/log/clamav/freshclam.log --daemon-notify=/etc/clamav/clamd.conf --config-file=/etc/clamav/freshclam.conf
-10 14 * * * /usr/bin/sa-update
+0 10 * * * sleep $(($RANDOM % 25200)); /usr/bin/freshclam --log=/var/log/clamav/freshclam.log --daemon-notify=/etc/clamav/clamd.conf --config-file=/etc/clamav/freshclam.conf;


### PR DESCRIPTION
Hello,
this patch is to distribute update time of clamav and spamassassin databases (it allows having multiple AgentJ instances on same server without stressing ressources).