### PR TITLE
fix: added failsafe for domain without domainkeys

### DIFF
--- a/app/src/Controller/DomainController.php
+++ b/app/src/Controller/DomainController.php
@@ -239,8 +239,8 @@ class DomainController extends AbstractController
                 }
             }
 
-        if ($domain->getDomainKeys() === null || $domain->getDomainKeys()->getPublicKey() === null)
-            $this->generateOpenDkim($domain);
+            if ($domain->getDomainKeys() === null || $domain->getDomainKeys()->getPublicKey() === null)
+                $this->generateOpenDkim($domain);
 
             $em->persist($wblist);
             $em->persist($userDomain);
@@ -402,6 +402,10 @@ class DomainController extends AbstractController
     private function generateOpenDkim(Domain $domain): bool
     {
         $dkim = $domain->getDomainKeys();
+        if ($dkim === null) {
+            $dkim = new DomainKey();
+            $domain->setDomainKeys($dkim);
+        }
         $dkim->setDomainName($domain->getDomain());
         $dkim->setSelector('agentj');
         try {

--- a/app/src/Controller/DomainController.php
+++ b/app/src/Controller/DomainController.php
@@ -260,12 +260,8 @@ class DomainController extends AbstractController
             return $this->redirectToRoute('domain_index');
         }
 
-        $dkim = null;
-        $dnsInfo = null;
-        if ($domain->getDomainKeys() !== null) {
-            $dkim = $this->em->getRepository(DomainKey::class)->find($domain->getDomainKeys()->getId());
-            $dnsInfo = $dkim->getDnsinfo();
-        }
+        $dkim = $domain->getDomainKeys();
+        $dnsInfo = $dkim?->getDnsinfo();
         return $this->render('domain/edit.html.twig', [
             'domain' => $domain,
             'dkim' => $dkim,

--- a/app/src/Controller/DomainController.php
+++ b/app/src/Controller/DomainController.php
@@ -239,8 +239,8 @@ class DomainController extends AbstractController
                 }
             }
 
-            if ($domain->getDomainKeys() === null || $domain->getDomainKeys()->getPublicKey() === null)
-                $this->generateOpenDkim($domain);
+        if ($domain->getDomainKeys() === null || $domain->getDomainKeys()->getPublicKey() === null)
+            $this->generateOpenDkim($domain);
 
             $em->persist($wblist);
             $em->persist($userDomain);
@@ -260,8 +260,12 @@ class DomainController extends AbstractController
             return $this->redirectToRoute('domain_index');
         }
 
-        $dkim = $this->em->getRepository(DomainKey::class)->find($domain->getDomainKeys()->getId());
-        $dnsInfo = $dkim->getDnsinfo();
+        $dkim = null;
+        $dnsInfo = null;
+        if ($domain->getDomainKeys() !== null) {
+            $dkim = $this->em->getRepository(DomainKey::class)->find($domain->getDomainKeys()->getId());
+            $dnsInfo = $dkim->getDnsinfo();
+        }
         return $this->render('domain/edit.html.twig', [
             'domain' => $domain,
             'dkim' => $dkim,

--- a/app/src/Entity/Domain.php
+++ b/app/src/Entity/Domain.php
@@ -117,7 +117,7 @@ class Domain
     private Collection $dailyStats;
 
     #[ORM\OneToOne(targetEntity: 'App\Entity\DomainKey', inversedBy: 'domain', cascade: ['persist'], orphanRemoval: true)]
-    private DomainKey $domain_keys;
+    private ?DomainKey $domain_keys = null;
 
     #[ORM\OneToMany(mappedBy: 'domain', targetEntity: DomainRelay::class, cascade: ['persist'], orphanRemoval: true)]
     private Collection $domainRelays;
@@ -138,7 +138,7 @@ class Domain
         $this->groups = new ArrayCollection();
         $this->connectors = new ArrayCollection();
         $this->dailyStats = new ArrayCollection();
-        $this->domain_keys = new DomainKey();
+        // $this->domain_keys = new DomainKey();
         $this->domainRelays = new ArrayCollection(); # ip addresses
     }
 

--- a/app/src/Entity/Domain.php
+++ b/app/src/Entity/Domain.php
@@ -117,7 +117,7 @@ class Domain
     private Collection $dailyStats;
 
     #[ORM\OneToOne(targetEntity: 'App\Entity\DomainKey', inversedBy: 'domain', cascade: ['persist'], orphanRemoval: true)]
-    private ?DomainKey $domain_keys = null;
+    private ?DomainKey $domain_keys;
 
     #[ORM\OneToMany(mappedBy: 'domain', targetEntity: DomainRelay::class, cascade: ['persist'], orphanRemoval: true)]
     private Collection $domainRelays;
@@ -138,7 +138,7 @@ class Domain
         $this->groups = new ArrayCollection();
         $this->connectors = new ArrayCollection();
         $this->dailyStats = new ArrayCollection();
-        // $this->domain_keys = new DomainKey();
+        $this->domain_keys = new DomainKey();
         $this->domainRelays = new ArrayCollection(); # ip addresses
     }
 

--- a/app/templates/domain/_form.html.twig
+++ b/app/templates/domain/_form.html.twig
@@ -62,7 +62,7 @@
             </div>
         </div>
         {#    DNS    #}
-        {% if domain.id is not null %}
+        {% if domain.id is not null and dkim is not null %}
             <div class="card mt-4 mb-4">
                 <div class="card-header">
                     {{ 'Entities.Domain.labels.dns' | trans() }}


### PR DESCRIPTION
## Related issue(s)
https://github.com/Probesys/agentj/issues/100

## How to test manually
-     Go to Domain index
-     Try to edit an existing Domain that doesnt have a domain_keys_id

## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works on both Firefox and Chrome
- [x] Tests are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
