### PR TITLE
policyd-rate-limit: hold over quota mail

### DIFF
--- a/policyd-rate-limit/policyd-rate-limit.yaml
+++ b/policyd-rate-limit/policyd-rate-limit.yaml
@@ -166,7 +166,7 @@ limit_by_ip: False
 success_action: "dunno"
 # If a limit is reach, which action postfix should do.
 # see http://www.postfix.org/access.5.html for a list of actions.
-fail_action: "defer_if_permit Rate limit reach, retry later"
+fail_action: "hold Rate limit reach, holding mail"
 # If we are unable to to contect the database backend, which action postfix should do.
 # see http://www.postfix.org/access.5.html for a list of actions.
 db_error_action: "dunno"


### PR DESCRIPTION


## Related issue(s)
#147

## How to test manually
send more mail than allowed by quota and verify they are not silently rejected and stay in postfix queue

## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works on both Firefox and Chrome
- [x] Tests are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
