### PR TITLE
fix: Fix action order on untreated and spam messages pages

### DIFF
--- a/app/src/Controller/MessageController.php
+++ b/app/src/Controller/MessageController.php
@@ -95,20 +95,20 @@ class MessageController extends AbstractController
                 default:
                     $subTitle = 'Entities.Message.untreated';
                     $messageActions = [
+                        'Message.Actions.Restore' => 'restore',
                         'Message.Actions.Autorized' => 'authorized',
                         'Message.Actions.Banned' => 'banned',
                         'Message.Actions.Delete' => 'delete',
-                        'Message.Actions.Restore' => 'restore',
                     ];
                     $type = MessageStatus::UNTREATED;
                     break;
             }
         } else {
             $messageActions = [
+                'Message.Actions.Restore' => 'restore',
                 'Message.Actions.Autorized' => 'authorized',
                 'Message.Actions.Banned' => 'banned',
                 'Message.Actions.Delete' => 'delete',
-                'Message.Actions.Restore' => 'restore',
             ];
             $subTitle = 'Entities.Message.untreated';
         }


### PR DESCRIPTION
## Related issue(s)
<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

https://github.com/Probesys/agentj/issues/92

## How to test manually
<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Open the "Actions" dropdown menu on the untreated and spam messages pages
2. Verify that the order of actions is : Recover, Authorize, Ban, Delete

## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works on both Firefox and Chrome
- [x] Tests are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
