### PR TITLE
Allow TLS for Postfix SMTP client

### DIFF
--- a/smtp/conf/out/postfix/main.cf
+++ b/smtp/conf/out/postfix/main.cf
@@ -34,3 +34,5 @@ non_smtpd_milters = inet:opendkim:8891
 transport_maps = proxy:mysql:/etc/conf/out/postfix/mysql-transport_map.cf
 
 maillog_file = /dev/stdout
+
+smtp_tls_security_level = may

--- a/smtp/conf/relay/postfix/main.cf
+++ b/smtp/conf/relay/postfix/main.cf
@@ -49,3 +49,5 @@ smtp_destination_concurrency_failed_cohort_limit = 10
 transport_maps = lmdb:/etc/conf/relay/postfix/slow_dest_domains_transport
 
 maillog_file = /dev/stdout
+
+smtp_tls_security_level = may


### PR DESCRIPTION
## Related issue(s)
Some email servers are not RFC 2487 compliant. This MR allows TLS for Postfix SMTP client. This is not the case by default.

## How to test manually
Send an email to a server allowing TLS only. Without this MR the email is bounced.

## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [ ] Code is manually tested
- [ ] Interface works on both mobiles and big screens
- [ ] Interface works on both Firefox and Chrome
- [ ] Tests are up to date
- [ ] Documentation is up to date
- [ ] Pull request has been reviewed and approved
