### PR TITLE
fix: Allow search on recipients as admin profile

### DIFF
--- a/app/src/Repository/MsgsRepository.php
+++ b/app/src/Repository/MsgsRepository.php
@@ -230,7 +230,7 @@ class MsgsRepository extends ServiceEntityRepository
 
         if ($searchKey) {
             // Check if $user is an admin
-            $isAdmin = $user && in_array('ROLE_ADMIN', $user->getRoles());
+            $isAdmin = $user && (in_array('ROLE_ADMIN', $user->getRoles()) || in_array('ROLE_SUPER_ADMIN', $user->getRoles()));
             if ($isAdmin) {
                 $sql .= ' AND (m.subject LIKE :searchKey OR maddr.email LIKE :searchKey OR m.from_addr LIKE :searchKey) ';
             } else {


### PR DESCRIPTION
## How to test manually
- [x] Login as admin or super admin and try to search on recipients field

## Reviewer checklist
- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works on both Firefox and Chrome
- [x] Tests are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
