### PR TITLE
chore(db): Upgrade to MariaDB 11.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog of AgentJ
 
+## unreleased
+
+### Migration notes
+
+MariaDB has been upgraded to version 11.4.
+While the system tables are automatically upgraded, user tables aren't.
+To fully upgrade all the tables, run the following command after restarting the stack.
+Please note that the command can take a long time for large databases.
+
+```console
+$ docker compose exec db mariadb-upgrade --force -uroot -p<ROOT PASSWORD>
+```
+
 ## 2025-07-17 - 2.1.4
 
 ### Bug fixes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 
 services:
   db:
-    image: mariadb:10.11
+    image: mariadb:11.4
     command: ["--default-authentication-plugin=mysql_native_password"]
     restart: always
     volumes:

--- a/mariadb-entrypoint-initdb.d/opendkim_user.sh
+++ b/mariadb-entrypoint-initdb.d/opendkim_user.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-mysql -u root -p"$MYSQL_ROOT_PASSWORD" "$MYSQL_DATABASE" \
+mariadb -u root -p"$MYSQL_ROOT_PASSWORD" "$MYSQL_DATABASE" \
 	-e "create user 'opendkim' identified by '$DB_OPENDKIM_PASSWORD'; grant select on $MYSQL_DATABASE.* to 'opendkim';"

--- a/scripts/mariadb
+++ b/scripts/mariadb
@@ -5,4 +5,4 @@ export COMPOSE_FILE=$SCRIPT_PATH/../docker-compose.yml
 
 source $SCRIPT_PATH/../.env
 
-docker compose exec db mysql -u $DB_USER -p$DB_PASSWORD "$@"
+docker compose exec db mariadb -u $DB_USER -p$DB_PASSWORD "$@"


### PR DESCRIPTION
## Related issue(s)
<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

Closes https://github.com/Probesys/agentj/issues/159

## Additional context

The last LTS of MariaDB is 11.8, but I decided to stick with 11.4 as the community support will end after the community support of 11.8 (because of changes in the MariaDB policy). See https://endoflife.date/mariadb

We use the `MARIADB_AUTO_UPGRADE` environment variable to automatically upgrade MariaDB tables. However, it only upgrades system tables, so a command is still needed to be run manually. An issue is opened in their bugtracker to allow upgrade user tables as well: https://github.com/MariaDB/mariadb-docker/issues/562

## How to test manually
<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Start the stack and run the command provided in the changelog
2. Verify that everything works and that AgentJ tables are upgraded

## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [ ] Code is manually tested
- [ ] Interface works on both mobiles and big screens
- [ ] Interface works on both Firefox and Chrome
- [ ] Tests are up to date
- [ ] Documentation is up to date
- [ ] Pull request has been reviewed and approved
