### PR TITLE
fix: show preview button only for untreated msgs

### DIFF
--- a/app/templates/message/index.html.twig
+++ b/app/templates/message/index.html.twig
@@ -131,12 +131,13 @@
 											<i class="fas fa-info"></i>
 										</a>
 									</li>
-									<li class="list-inline-item">
-
-										<a href="#" title="{{ 'Entities.Message.labels.preview' | trans }}" data-modal-method-type="GET" data-url-modal-content="{{ path('message_show_content', {'partitionTag' : msgRecipient.partitionTag, 'mailId' : msgRecipient.getMailIdAsString(), 'rid' : msgRecipient.rid.id}) }}" class="btn-open-modal btn btn-info float-right">
-											<i class="fas fa-envelope-open"></i>
-										</a>
-									</li>
+									{% if messageStatus is null %}
+										<li class="list-inline-item">
+											<a href="#" title="{{ 'Entities.Message.labels.preview' | trans }}" data-modal-method-type="GET" data-url-modal-content="{{ path('message_show_content', {'partitionTag' : msgRecipient.partitionTag, 'mailId' : msgRecipient.getMailIdAsString(), 'rid' : msgRecipient.rid.id}) }}" class="btn-open-modal btn btn-info float-right">
+												<i class="fas fa-envelope-open"></i>
+											</a>
+										</li>
+									{% endif %}
 								</ul>
 							</td>
 


### PR DESCRIPTION
## Related issue(s)
https://github.com/Probesys/agentj/issues/203

## How to test manually
- [x] Open the application
- [x] Send an email
- [x] Verify that the mail is in the untreated list and that the preview button is displayed
- [x] Change the bspam_level and/or the status or content column in database
- [x] Verify that the preview button is not displayed in other catagories (spam, virus, restored, etc.)

## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works on both Firefox and Chrome
- [x] Tests are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
