### PR TITLE
fix: Close modal user form after submit

### DIFF
--- a/app/public/js/agentj.js
+++ b/app/public/js/agentj.js
@@ -159,7 +159,6 @@ document.addEventListener("turbo:load", function () {
       processData: false,
       contentType: false,
       success: function (data) {
-        data = $.parseJSON(data);
         var message = "";
         if (typeof data.message !== "undefined") {
           message = data.message;

--- a/app/src/Controller/GroupsController.php
+++ b/app/src/Controller/GroupsController.php
@@ -77,10 +77,10 @@ class GroupsController extends AbstractController
         if ($form->isSubmitted() && $form->isValid()) {
             $labelExists = $this->checkNameforDomain($group->getName(), $form->get('domain')->getData());
             if ($labelExists) {
-                return new JsonResponse(json_encode([
+                return new JsonResponse([
                             'status' => 'danger',
                             'message' => $this->translator->trans('Generics.flash.groupNameAlreadyExist'),
-                ]));
+                ]);
             }
 
             $this->em->persist($group);
@@ -98,10 +98,10 @@ class GroupsController extends AbstractController
             $this->em->persist($groupsWblist);
 
             $this->em->flush();
-            return new JsonResponse(json_encode([
+            return new JsonResponse([
                         'status' => 'success',
                         'message' => $this->translator->trans('Generics.flash.addSuccess'),
-                    ]), 200);
+                    ], 200);
         }
 
         return $this->render('groups/new.html.twig', [
@@ -143,10 +143,10 @@ class GroupsController extends AbstractController
             if ($oldName != $group->getName() || $olddomain != $group->getDomain()) {
                 $labelExists = $this->checkNameforDomain($group->getName(), $form->get('domain')->getData());
                 if ($labelExists) {
-                    return new JsonResponse(json_encode([
+                    return new JsonResponse([
                                 'status' => 'danger',
                                 'message' => $this->translator->trans('Generics.flash.groupNameAlreadyExist'),
-                    ]));
+                    ]);
                 }
             }
 
@@ -174,10 +174,10 @@ class GroupsController extends AbstractController
 
             $this->em->flush();
 
-            return new JsonResponse(json_encode([
+            return new JsonResponse([
                         'status' => 'success',
                         'message' => $this->translator->trans('Generics.flash.editSuccess'),
-                    ]), 200);
+                    ], 200);
         }
 
         return $this->render('groups/edit.html.twig', [


### PR DESCRIPTION
## Related issue(s)

https://github.com/Probesys/agentj/issues/219

## How to test manually
- Go to User -> Email accounts
- Click on New user
- Submit form. The modal should close itself

## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works on both Firefox and Chrome
- [x] Tests are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
