### PR TITLE
fix: Fetch sender email correctly for virus alerts

### DIFF
--- a/app/src/Entity/OutMsg.php
+++ b/app/src/Entity/OutMsg.php
@@ -20,8 +20,9 @@ class OutMsg
     #[ORM\Column(type: 'integer', nullable: true)]
     private ?int $statusId;
 
-    #[ORM\Column(type: 'bigint', nullable: true, options: ['unsigned' => true])]
-    private mixed $sid;
+    #[ORM\JoinColumn(name: 'sid', referencedColumnName: 'id')]
+    #[ORM\ManyToOne(targetEntity: Maddr::class)]
+    private ?Maddr $sid;
 
     #[ORM\Column(type: 'binary', length: 255, nullable: true)]
     private mixed $secretId;
@@ -113,7 +114,7 @@ class OutMsg
         return $this->statusId;
     }
 
-    public function getSid(): ?int
+    public function getSid(): ?Maddr
     {
         return $this->sid;
     }
@@ -252,7 +253,7 @@ class OutMsg
         return $this;
     }
 
-    public function setSid(?string $sid): static
+    public function setSid(?Maddr $sid): static
     {
         $this->sid = $sid;
 

--- a/app/src/MessageHandler/CreateAlertMessageHandler.php
+++ b/app/src/MessageHandler/CreateAlertMessageHandler.php
@@ -77,8 +77,8 @@ class CreateAlertMessageHandler
             if ($outMsg->getContent() === 'V') {
                 $target = $message->getTarget();
 
-                // Fetch the user who sent the email based on from_addr
-                $fromAddr = $outMsg->getFromAddr();
+                // Fetch the user who sent the email
+                $fromAddr = $outMsg->getSid()->getEmailClear();
                 $senderUser = $this->entityManager->getRepository(User::class)->findOneBy(['email' => $fromAddr]);
 
                 $timezone = new \DateTimeZone('Europe/Paris');


### PR DESCRIPTION
## Related issue(s)
<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

N/A

## How to test manually
<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. change the script `mail_via_agentj.sh` to add these two arguments: `--h-From 'User <user@blocnormal.fr>' --attach @tests/eicar.com.txt`
2. send an email with `scripts/mail_via_agentj.sh`
3. generate alerts for admin and user with the following command: `scripts/console app:create-alert-for-user`
4. Verify that the alert is generated for the outgoing email and there is no warning in the log saying `No user found with email: User <user@blocnormal.fr>`

## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works on both Firefox and Chrome
- [x] Tests are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
