### PR TITLE
Enable mariadbupgrade in healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - TZ
       - DB_OPENDKIM_PASSWORD
     healthcheck:
-      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized", "--mariadbupgrade"]
       start_period: 10s
       interval: 10s
       timeout: 5s


### PR DESCRIPTION
Use healthcheck to monitor if a mariadb-upgrade is needed.