### PR TITLE
sec: Make report tokens unique per email

### DIFF
--- a/app/src/Command/ReportSendMailCommand.php
+++ b/app/src/Command/ReportSendMailCommand.php
@@ -5,7 +5,6 @@ namespace App\Command;
 use App\Entity\User;
 use App\Amavis\MessageStatus;
 use App\Repository\MsgrcptSearchRepository;
-use App\Service;
 use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -15,8 +14,6 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
-use Symfony\Component\Mailer\Mailer;
-use Symfony\Component\Mailer\Transport;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -33,7 +30,6 @@ class ReportSendMailCommand extends Command
         private ManagerRegistry $doctrine,
         private TranslatorInterface $translator,
         private MailerInterface $mailer,
-        private Service\CryptEncryptService $cryptEncryptService,
         #[Autowire(param: 'app.domain_mail_authentification_sender')]
         private string $defaultMailFrom,
         private ParameterBagInterface $params,
@@ -94,12 +90,10 @@ class ReportSendMailCommand extends Command
                     $body = $this->translator->trans('Message.Report.defaultAlertMailContent');
                 }
 
-                $token = $this->cryptEncryptService->encrypt((string) $user->getId(), lifetime: 48 * 3600);
-
                 $tableMsgs = $this->twig->render('report/table_mail_msgs.html.twig', [
                     'untreatedMsgs' => $untreatedMsgs,
                     'url' => $url,
-                    'token' => $token,
+                    'user' => $user,
                 ]);
 
                 $body = str_replace('[USERNAME]', $user->getFullname(), $body);

--- a/app/src/Twig/AppExtension.php
+++ b/app/src/Twig/AppExtension.php
@@ -3,17 +3,22 @@
 namespace App\Twig;
 
 use App\Entity\Groups;
+use App\Entity\Msgs;
 use App\Entity\User;
 use App\Entity\Wblist;
+use App\Service\MessageService;
 use Doctrine\ORM\EntityManagerInterface;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
+use Twig\TwigFunction;
 use Doctrine\DBAL\Connection;
 
 class AppExtension extends AbstractExtension
 {
-    public function __construct(private EntityManagerInterface $em)
-    {
+    public function __construct(
+        private EntityManagerInterface $em,
+        private MessageService $messageService,
+    ) {
     }
 
     /**
@@ -26,6 +31,13 @@ class AppExtension extends AbstractExtension
             new TwigFilter('stream_get_contents', [$this, 'streamGetcontent']),
             new TwigFilter('user_groups', [$this, 'getUserGroups']),
             new TwigFilter('wblist_is_overridden', [$this, 'wbListIsOverriden']),
+        ];
+    }
+
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('message_release_token', [$this, 'messageReleaseToken']),
         ];
     }
 
@@ -78,5 +90,10 @@ class AppExtension extends AbstractExtension
     {
 
         return $this->em->getRepository(Wblist::class)->wbListIsOverriden($wbInfo);
+    }
+
+    public function messageReleaseToken(Msgs $message, User $user): string
+    {
+        return $this->messageService->getReleaseToken($message, $user);
     }
 }

--- a/app/templates/report/table_mail_msgs.html.twig
+++ b/app/templates/report/table_mail_msgs.html.twig
@@ -1,7 +1,8 @@
 {% if untreatedMsgs is not empty %}
   <table style="width:100%;background-color: #fff;">
     <tbody>
-      {% for msg in  untreatedMsgs%}
+      {% for msg in untreatedMsgs %}
+        {% set token = message_release_token(msg.msgs, user) %}
         <tr>
 
           <td>


### PR DESCRIPTION
## Related issue(s)
<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

N/A

## How to test manually
<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Make sure that the `user@blocnormal.fr` reports are enabled and that the `blocnormal.fr` domain has a report template containing the `[LIST_MAIL_MSGS]` variable
2. Send two emails with `scripts/mail_to_agentj.sh` (change the `from` address between the two calls)
3. Send the report with `scripts/console agentj:report-send-mail`
4. Extract the two links to the authorized endpoints, and inverse the tokens
5. In private window, try to reach one of the endpoint
6. Verify that it fails and that the sender is not authorized

## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works on both Firefox and Chrome
- [x] Tests are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
