### PR TITLE
chore(app): Unregister residual service workers

### DIFF
--- a/app/public/js/agentj.js
+++ b/app/public/js/agentj.js
@@ -320,3 +320,14 @@ function hideAlertMessage() {
     $(this).remove();
   });
 }
+
+// Unregister residual service workers.
+// See https://github.com/Probesys/agentj/pull/162
+// TODO remove this code in AgentJ >= 2.3
+if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.getRegistrations().then(function(registrations) {
+        for (let registration of registrations) {
+            registration.unregister();
+        }
+    });
+}


### PR DESCRIPTION
## Context

We removed a useless service worker in a1f0fb2, but it was still registered in browsers which installed it. This generates 404 errors on the server as the browsers try to fetch it.

## Related issue(s)
<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

https://github.com/Probesys/agentj/pull/162

## How to test manually
<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

N/A

## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works on both Firefox and Chrome
- [x] Tests are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
