### PR TITLE
sec: Fix a SQL injection in advanced search

### DIFF
--- a/app/src/Repository/MsgsRepository.php
+++ b/app/src/Repository/MsgsRepository.php
@@ -332,9 +332,20 @@ class MsgsRepository extends ServiceEntityRepository
         }
 
         if ($sortParams) {
-            $sql .= ' ORDER BY ' . $sortParams['sort'] . ' ' . $sortParams['direction'];
+            $sortField = $sortParams['sort'];
+            $sortDirection = $sortParams['direction'];
+
+            if (!in_array($sortField, ['mail_id', 'from_addr', 'email', 'subject', 'time_iso'])) {
+                $sortField = 'm.time_num';
+            }
+
+            if ($sortDirection !== 'asc' && $sortDirection !== 'desc') {
+                $sortDirection = 'desc';
+            }
+
+            $sql .= " ORDER BY {$sortField} {$sortDirection}";
         } else {
-            $sql .= ' ORDER BY m.time_num desc, m.status_id ';
+            $sql .= ' ORDER BY m.time_num desc, m.status_id';
         }
 
         $stmt = $conn->prepare($sql);


### PR DESCRIPTION
## Context

The advanced search was subject to an attack by SQL injection. A malicious user with admin rights could forge a request and alter the sort parameters in order to execute a SQL request, such as a DELETE statement.

The attack is difficult to exploit by an external attacker as a POST request must be performed and the session cookies are not sent if the HTTP request is performed from outside AgentJ thanks to the `SameSite` policy.

## Related issue(s)
<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

N/A

## How to test manually
<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. In the advanced search, open the dev console
2. Perform a search and edit the HTTP request to perform a SQL injection of your own
3. Verify that the request is not executed

## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works on both Firefox and Chrome
- [x] Tests are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
