### PR TITLE
fix: Fix sending auth email if fullname is null

### DIFF
--- a/app/src/Command/SendAuthMailRequestCommand.php
+++ b/app/src/Command/SendAuthMailRequestCommand.php
@@ -122,6 +122,11 @@ class SendAuthMailRequestCommand extends Command
                 $fromName = $this->getMailFromName($messageRecipients[0]);
                 $mailBody = $this->createAuthEmailContent($domain, $message, $messageRecipients);
                 $email = $this->createAuthEmail($message, $mailFrom, $fromName, $mailBody);
+
+                if ($email === null) {
+                    continue;
+                }
+
                 if ($this->sendAuthEmail($message, $email)) {
                     $logService = new LogService($this->em);
                     $logService->addLog(
@@ -212,15 +217,18 @@ class SendAuthMailRequestCommand extends Command
     private function createAuthEmail(
         Msgs $message,
         string $mailFrom,
-        string $fromName,
+        ?string $fromName,
         array $body
-    ): Email {
+    ): ?Email {
         $mailTo = $message->getSid()->getEmailClear();
         try {
             $subject = $this->getSubject($message);
             $email = new Email();
+
+            $fromAddress = $fromName ? new Address($mailFrom, $fromName) : new Address($mailFrom);
+
             $email->subject($subject)
-                  ->from(new Address($mailFrom, $fromName))
+                  ->from($fromAddress)
                   ->to($mailTo)
                   ->html($body['html_body'])
                   ->text(strip_tags($body['plain_body']));
@@ -289,7 +297,7 @@ class SendAuthMailRequestCommand extends Command
         return $mailFrom;
     }
 
-    private function getMailFromName(Msgrcpt $msgrcpt): string
+    private function getMailFromName(Msgrcpt $msgrcpt): ?string
     {
         $userRepository = $this->em->getRepository(User::class);
         $user = $userRepository->findOneBy(['email' => $msgrcpt->getRid()->getEmailClear()]);


### PR DESCRIPTION
## Related issue(s)
N/A

## How to test manually
- [x] Send an email to an agent user that doest not have fullname provided
- [x] Check that you receive an authentication request

## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works on both Firefox and Chrome
- [x] Tests are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
