### PR TITLE
fix(smtp): Fix the mailer headers when sending emails

### DIFF
--- a/app/config/packages/mailer.yaml
+++ b/app/config/packages/mailer.yaml
@@ -1,7 +1,3 @@
 framework:
     mailer:
         dsn: '%env(SMTP_TRANSPORT)%'
-        envelope:
-            sender: '%env(DOMAIN_MAIL_AUTHENTIFICATION_SENDER)%'
-        headers:
-            from: '%env(DOMAIN_MAIL_AUTHENTIFICATION_SENDER)%'

--- a/app/src/Command/ReportSendMailCommand.php
+++ b/app/src/Command/ReportSendMailCommand.php
@@ -105,7 +105,12 @@ class ReportSendMailCommand extends Command
                 $body = str_replace('[NB_DELETED_MESSAGES]', (string) $nbDeleted, $body);
                 $body = str_replace('[URL_MSGS]', $url, $body);
 
+                $from = $domain->getMailAuthenticationSender();
+                if (!$from) {
+                    $from = $this->defaultMailFrom;
+                }
                 $fromName = $this->translator->trans('Entities.Report.mailFromName');
+                $fromAddress = new Address($from, $fromName);
 
                 $mailTo = $user->getEmailFromRessource();
 
@@ -120,7 +125,7 @@ class ReportSendMailCommand extends Command
 
                 $message = new Email();
                 $message->subject($this->translator->trans('Message.Report.defaultMailSubject') . $mailTo)
-                        ->from(new Address($this->defaultMailFrom, $fromName))
+                        ->from($fromAddress)
                         ->to($toAddress)
                         ->html($body)->text(strip_tags($bodyTextPlain));
 

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -142,7 +142,7 @@ then
 
 	$dx php bin/console ag:report >/dev/null
 	expected_subject="Messages en attente sur AgentJ pour user@blocnormal.fr" \
-		expected_sender="no-reply@${APP_DOMAIN:-$DOMAIN}" \
+		expected_sender="will@blocnormal.fr" \
 		to_addr="user@blocnormal.fr" \
 		send 'report' 'out' 'user@blocnormal.fr' 1 0
 


### PR DESCRIPTION
## Related issue(s)
<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

N/A

## How to test manually
<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Set a custom SMTP sender in the blocnormal.fr domain (e.g. `noreply@blocnormal.fr`)
2. Make sure that `root@smtp.test` is not authorized by `user@blocnormal.fr`
3. Make sure to enable the report for the user `user@blocnormal.fr`
4. Send an email with the command `scripts/mail_to_agentj.sh`
5. Send the report and authorization emails:
    ```
    scripts/console agentj:report-send-mail
    scripts/console agentj:send-auth-mail-token
    ```
6. In Mailpit, check the headers of both emails, and verify the From and Return-Path headers are set to `noreply@blocnormal.fr`. Sender should not be set as it's not required (and thus, not set anymore by us).

## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works on both Firefox and Chrome
- [x] Tests are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
