### PR TITLE
fix: Replace NB_UNTREATED_MESSAGES in the reports

### DIFF
--- a/app/config/packages/mailer.yaml
+++ b/app/config/packages/mailer.yaml
@@ -1,7 +1,3 @@
 framework:
     mailer:
         dsn: '%env(SMTP_TRANSPORT)%'
-        envelope:
-            sender: '%env(DOMAIN_MAIL_AUTHENTIFICATION_SENDER)%'
-        headers:
-            from: '%env(DOMAIN_MAIL_AUTHENTIFICATION_SENDER)%'

--- a/app/src/Command/ReportSendMailCommand.php
+++ b/app/src/Command/ReportSendMailCommand.php
@@ -77,6 +77,7 @@ class ReportSendMailCommand extends Command
                 }
 
                 $untreatedMsgs = array_slice($untreatedMsgs, 0, 10);
+                $nbUntreated = $this->msgrcptSearchRepository->countByType($user, MessageStatus::UNTREATED);
                 $nbAuthorized = $this->msgrcptSearchRepository->countByType($user, MessageStatus::AUTHORIZED);
                 $nbBanned = $this->msgrcptSearchRepository->countByType($user, MessageStatus::BANNED);
                 $nbDeleted = $this->msgrcptSearchRepository->countByType($user, MessageStatus::DELETED);
@@ -98,6 +99,7 @@ class ReportSendMailCommand extends Command
 
                 $body = str_replace('[USERNAME]', $user->getFullname(), $body);
                 $body = str_replace('[LIST_MAIL_MSGS]', $tableMsgs, $body);
+                $body = str_replace('[NB_UNTREATED_MESSAGES]', (string) $nbUntreated, $body);
                 $body = str_replace('[NB_AUTHORIZED_MESSAGES]', (string) $nbAuthorized, $body);
                 $body = str_replace('[NB_SPAMMED_MESSAGES]', (string) $nbSpammed, $body);
                 $body = str_replace('[NB_BANNED_MESSAGES]', (string) $nbBanned, $body);

--- a/app/src/Command/ReportSendMailCommand.php
+++ b/app/src/Command/ReportSendMailCommand.php
@@ -105,7 +105,12 @@ class ReportSendMailCommand extends Command
                 $body = str_replace('[NB_DELETED_MESSAGES]', (string) $nbDeleted, $body);
                 $body = str_replace('[URL_MSGS]', $url, $body);
 
+                $from = $domain->getMailAuthenticationSender();
+                if (!$from) {
+                    $from = $this->defaultMailFrom;
+                }
                 $fromName = $this->translator->trans('Entities.Report.mailFromName');
+                $fromAddress = new Address($from, $fromName);
 
                 $mailTo = $user->getEmailFromRessource();
 
@@ -120,7 +125,7 @@ class ReportSendMailCommand extends Command
 
                 $message = new Email();
                 $message->subject($this->translator->trans('Message.Report.defaultMailSubject') . $mailTo)
-                        ->from(new Address($this->defaultMailFrom, $fromName))
+                        ->from($fromAddress)
                         ->to($toAddress)
                         ->html($body)->text(strip_tags($bodyTextPlain));
 

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -142,7 +142,7 @@ then
 
 	$dx php bin/console ag:report >/dev/null
 	expected_subject="Messages en attente sur AgentJ pour user@blocnormal.fr" \
-		expected_sender="no-reply@${APP_DOMAIN:-$DOMAIN}" \
+		expected_sender="will@blocnormal.fr" \
 		to_addr="user@blocnormal.fr" \
 		send 'report' 'out' 'user@blocnormal.fr' 1 0
 


### PR DESCRIPTION
## Related issue(s)
<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

N/A

## How to test manually
<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. In the blocnormal.fr domain "report" template, add the variable `NB_UNTREATED_MESSAGES`
2. Make sure to have an untreated email, and send the reports (`scripts/console agentj:report-send-mail`)
3. Verify that the variable in the email has been replaced by the real number of untreated messages

## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works on both Firefox and Chrome
- [x] Tests are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
