### PR TITLE
fix(Command): #262 ignore aliases if they match the main email

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 .cache/
 .local/
 mailpit/
+.vscode/


### PR DESCRIPTION
## Related issue(s)
(https://github.com/Probesys/agentj/issues/262)

## How to test manually
- create a domain
- create an LDAP connector
- import the users
-> it should ignore the duplicates, and so, the aliases that are equal to the main email

## Reviewer checklist

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works on both Firefox and Chrome
- [x] Tests are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
