### PR TITLE
fix: Sync user domain with his email domain on edition

### DIFF
--- a/app/src/Controller/UserController.php
+++ b/app/src/Controller/UserController.php
@@ -510,9 +510,10 @@ class UserController extends AbstractController
                     'message' => $this->translator->trans('Generics.flash.imapLoginAlreadyExist'),
                 ];
             } elseif ($form->isValid()) {
+                $user->setUsername($user->getEmail());
+                $user->setDomain($newDomain);
                 $policy = $this->computeUserPolicy($user);
                 $user->setPolicy($policy);
-                $user->setUsername($user->getEmail());
 
                 $this->em->persist($user);
                 $this->em->flush();


### PR DESCRIPTION
## Related issue(s)
<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

N/A

## How to test manually
<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Get the domain of the user `user@blocnormal.fr` and check it is `blocnormal.fr`:
    `scripts/mariadb agentj -e 'select d.domain from users u, domain d where u.domain_id = d.id and email = "user@blocnormal.fr"'`
1. In the interface, change the email of the user `user@blocnormal.fr` to `test@laissepasser.fr`
3. Get the domain of the user and verify it changed to `laissepasser.fr`:
    `scripts/mariadb agentj -e 'select d.domain from users u, domain d where u.domain_id = d.id and email = "test@laissepasser.fr"'`
4. Optional: revert the change in the interface

## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works on both Firefox and Chrome
- [x] Tests are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
