### PR TITLE
fix: Order messages by date desc by default

### DIFF
--- a/app/src/Controller/MessageController.php
+++ b/app/src/Controller/MessageController.php
@@ -158,6 +158,8 @@ class MessageController extends AbstractController
                 'wrap-queries' => true,
                 'fetchJoinCollection' => false,
                 'distinct' => false,
+                'defaultSortFieldName' => 'm.timeNum',
+                'defaultSortDirection' => 'desc',
             ]
         );
         return $this->render('message/index.html.twig', [


### PR DESCRIPTION
## Related issue(s)
<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

N/A

## How to test manually
<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Send several emails to a AgentJ account
2. Open the list of emails
3. Verify the emails are ordered by date desc by default

<img width="84" height="38" alt="image" src="https://github.com/user-attachments/assets/712e09a3-779e-4a0a-9e31-fa661bccfcfe" />


## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works on both Firefox and Chrome
- [x] Tests are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
