### PR TITLE
fix(ldap): handle unmanaged domains on import

### DIFF
--- a/app/src/Repository/DomainRepository.php
+++ b/app/src/Repository/DomainRepository.php
@@ -53,4 +53,12 @@ class DomainRepository extends ServiceEntityRepository
 
         return $query;
     }
+
+    /**
+     * Find a domain by its name
+     */
+    public function findOneByDomain(string $domainName): ?Domain
+    {
+        return $this->findOneBy(['domain' => strtolower($domainName)]);
+    }
 }

--- a/app/src/Util/Email.php
+++ b/app/src/Util/Email.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Util;
+
+class Email
+{
+    /**
+     * Extract the domain from an email address
+     */
+    public static function extractDomain(string $email): ?string
+    {
+        $parts = explode('@', $email);
+        return count($parts) === 2 ? strtolower($parts[1]) : null;
+    }
+}


### PR DESCRIPTION
BREAKING CHANGE: Users and aliases with unmanaged domains are now ignored

- User.domain is now derived from user email instead of connector
- Alias.domain is now derived from its own email
- Ignore import when domain is unmanaged
- Preserve Group.originConnector during updates

## Related issue(s)
<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

https://github.com/Probesys/agentj/issues/263

## How to test manually
<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works on both Firefox and Chrome
- [x] Tests are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
