### PR TITLE
fix(LDAPImportCommand) - #286 ignore invalid emails when importing ldap users

### DIFF
--- a/app/src/Command/LDAPImportCommand.php
+++ b/app/src/Command/LDAPImportCommand.php
@@ -131,6 +131,9 @@ class LDAPImportCommand extends Command
                 $listAliases = array_unique($listAliases);
 
                 foreach ($listAliases as $aliasEmail) {
+                    if (!filter_var($aliasEmail, FILTER_VALIDATE_EMAIL)) {
+                        continue;
+                    }
                     $this->createAlias($user, $aliasEmail);
                 }
 


### PR DESCRIPTION
Ignore invalid emails when importing ldap users

## Related issue(s)
(https://github.com/Probesys/agentj/issues/286)

## How to test manually
Add invalid mail values in the ldap file (ex : tree.ldif) you use when importing new users, then try to import.
The invalid emails should be ignored.

## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works on both Firefox and Chrome
- [x] Tests are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
