### PR TITLE
261 ldap allow to attach imported users to one or more groups

### DIFF
--- a/app/migrations/Version20250915140131.php
+++ b/app/migrations/Version20250915140131.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250915140131 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add connector_groups table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE connector_groups (
+            connector_id INT NOT NULL,
+            groups_id INT NOT NULL,
+            INDEX IDX_262FEFCF4D085745 (connector_id),
+            INDEX IDX_262FEFCFF373DCF (groups_id),
+            PRIMARY KEY(connector_id, groups_id)
+        ) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+
+        $this->addSql('ALTER TABLE connector_groups
+            ADD CONSTRAINT FK_262FEFCF4D085745
+            FOREIGN KEY (connector_id)
+            REFERENCES connector (id)
+            ON DELETE CASCADE');
+
+        $this->addSql('ALTER TABLE connector_groups
+            ADD CONSTRAINT FK_262FEFCFF373DCF
+            FOREIGN KEY (groups_id)
+            REFERENCES groups (id)
+            ON DELETE CASCADE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE connector_groups
+            DROP FOREIGN KEY FK_262FEFCF4D085745');
+        $this->addSql('ALTER TABLE connector_groups
+            DROP FOREIGN KEY FK_262FEFCFF373DCF');
+        $this->addSql('DROP TABLE connector_groups');
+    }
+}

--- a/app/public/js/agentj.js
+++ b/app/public/js/agentj.js
@@ -129,7 +129,7 @@ document.addEventListener("turbo:load", function () {
         $('.select2').select2(
           {
             width: 'resolve',
-            dropdownParent: $('#empModal')
+            dropdownParent: $('.modal-content')
           }
         );
         $('#empModal').modal('show');
@@ -142,7 +142,7 @@ document.addEventListener("turbo:load", function () {
     $('#empModal').modal('toggle');
   });
 
-  // Manage ajax form    
+  // Manage ajax form
 
   $('body').on('submit', 'form.modal-ajax-form', function (e) {
     e.preventDefault();

--- a/app/src/Command/LDAPImportCommand.php
+++ b/app/src/Command/LDAPImportCommand.php
@@ -267,7 +267,6 @@ class LDAPImportCommand extends Command
         $this->groupService->updateWblist();
     }
 
-
     private function importGroups(): void
     {
         $realNameAttribute = $this->connector->getLdapGroupNameField();

--- a/app/src/Controller/LdapConnectorController.php
+++ b/app/src/Controller/LdapConnectorController.php
@@ -48,7 +48,12 @@ class LdapConnectorController extends AbstractController
         $connector = new LdapConnector();
         $connector->setDomain($domain);
         $form = $this->createForm(LdapConnectorType::class, $connector, [
-            'action' => $this->generateUrl('app_connector_ldap_new', ['domain' => $domain->getId()]),
+            'action' => $this->generateUrl(
+                'app_connector_ldap_new',
+                [
+                    'domain' => $domain->getId()
+                ]
+            ),
         ]);
         $form->handleRequest($request);
 
@@ -120,10 +125,11 @@ class LdapConnectorController extends AbstractController
         return $this->redirectToRoute('domain_edit', ['id' => $connector->getDomain()->getId()]);
     }
 
-    #[Route('/checkbind', name: 'app_connector_ldap_checkbind', methods: ['GET', 'POST'])]
-    public function checkbindAction(Request $request, LdapService $ldapService): Response
+    #[Route('/checkbind/{domain}', name: 'app_connector_ldap_checkbind', methods: ['GET', 'POST'])]
+    public function checkbindAction(Request $request, LdapService $ldapService, Domain $domain): Response
     {
         $testConnector = new LdapConnector();
+        $testConnector->setDomain($domain);
         $form = $this->createForm(LdapConnectorType::class, $testConnector);
         $form->handleRequest($request);
 
@@ -161,12 +167,12 @@ class LdapConnectorController extends AbstractController
     {
 
         $testConnector = new LdapConnector();
+        $testConnector->setDomain($domain);
         $form = $this->createForm(LdapConnectorType::class, $testConnector);
         $form->handleRequest($request);
 
         if ($form->isSubmitted()) {
             $testConnector = $form->getData();
-            $testConnector->setDomain($domain);
             $pass = $request->request->get('encryptedPass');
             if ($testConnector->getLdapPassword()) {
                 $pass = $this->cryptEncryptService->encrypt($testConnector->getLdapPassword());

--- a/app/src/Entity/Connector.php
+++ b/app/src/Entity/Connector.php
@@ -48,10 +48,17 @@ class Connector
     #[ORM\Column(nullable: true)]
     private ?bool $synchronizeGroup = null;
 
+    /**
+     * @var Collection<int, Groups>
+     */
+    #[ORM\ManyToMany(targetEntity: Groups::class, inversedBy: 'connectors')]
+    private Collection $targetGroups;
+
     public function __construct()
     {
         $this->users = new ArrayCollection();
         $this->groups = new ArrayCollection();
+        $this->targetGroups = new ArrayCollection();
     }
 
     public function getId(): ?int
@@ -163,6 +170,30 @@ class Connector
     public function setSynchronizeGroup(?bool $synchronizeGroup): self
     {
         $this->synchronizeGroup = $synchronizeGroup;
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, Groups>
+     */
+    public function getTargetGroups(): Collection
+    {
+        return $this->targetGroups;
+    }
+
+    public function addTargetGroup(Groups $targetGroup): static
+    {
+        if (!$this->targetGroups->contains($targetGroup)) {
+            $this->targetGroups->add($targetGroup);
+        }
+
+        return $this;
+    }
+
+    public function removeTargetGroup(Groups $targetGroup): static
+    {
+        $this->targetGroups->removeElement($targetGroup);
 
         return $this;
     }

--- a/app/src/Entity/Groups.php
+++ b/app/src/Entity/Groups.php
@@ -87,6 +87,12 @@ class Groups
     #[ORM\Column(nullable: true)]
     private ?array $quota = null;
 
+    /**
+     * @var Collection<int, Connector>
+     */
+    #[ORM\ManyToMany(targetEntity: Connector::class, mappedBy: 'targetGroups')]
+    private Collection $connectors;
+
     public function __toString()
     {
         return $this->name;
@@ -99,6 +105,7 @@ class Groups
         $this->rights = new ArrayCollection();
         $this->users = new ArrayCollection();
         $this->groupsWbLists = new ArrayCollection();
+        $this->connectors = new ArrayCollection();
     }
 
 
@@ -368,6 +375,33 @@ class Groups
     public function setQuota(?array $quota): static
     {
         $this->quota = $quota;
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, Connector>
+     */
+    public function getConnectors(): Collection
+    {
+        return $this->connectors;
+    }
+
+    public function addConnector(Connector $connector): static
+    {
+        if (!$this->connectors->contains($connector)) {
+            $this->connectors->add($connector);
+            $connector->addTargetGroup($this);
+        }
+
+        return $this;
+    }
+
+    public function removeConnector(Connector $connector): static
+    {
+        if ($this->connectors->removeElement($connector)) {
+            $connector->removeTargetGroup($this);
+        }
 
         return $this;
     }

--- a/app/src/Form/LdapConnectorType.php
+++ b/app/src/Form/LdapConnectorType.php
@@ -3,7 +3,9 @@
 namespace App\Form;
 
 use App\Entity\LdapConnector;
-use Symfony\Component\Form\AbstractType;
+use App\Entity\Groups;
+use App\Repository\GroupsRepository;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -13,6 +15,9 @@ class LdapConnectorType extends ConnectorType
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         parent::buildForm($builder, $options);
+
+        $domain = $builder->getData()->getDomain();
+
         $builder
             ->add('ldapHost', null, [
                 'required' => true,
@@ -39,6 +44,19 @@ class LdapConnectorType extends ConnectorType
                 'required' => is_null($builder->getData()->getId()),
                 'label' => 'Entities.LdapConnector.fields.LdapPassword',
                 'attr' => ['data-ldap-bind' => 'true']
+            ])
+            ->add('targetGroups', EntityType::class, [
+                'attr' => ['class' => 'select2'],
+                'required' => false,
+                'class' => Groups::class,
+                'multiple' => true,
+                'expanded' => false,
+                'query_builder' => function (GroupsRepository $groupsRepository) use ($domain) {
+                    return $groupsRepository->createQueryBuilder('g')
+                        ->where('g.domain = :domain')
+                        ->setParameter('domain', $domain);
+                },
+                'label' => 'Entities.Connector.fields.targetGroups',
             ])
             ->add('ldapRealNameField', null, [
                 'required' => true,

--- a/app/templates/connector/_form_ldap.html.twig
+++ b/app/templates/connector/_form_ldap.html.twig
@@ -1,30 +1,40 @@
 {{ form_start(form, { "attr" : {'data-controller' : 'form-ldap-connector'}}) }}
-<input type="hidden" value="{{ path('app_connector_ldap_checkbind') }}" data-form-ldap-connector-target="urlCheckBind">
+
+<input type="hidden" value="{{ path('app_connector_ldap_checkbind', { 'domain' : connector.domain.id }) }}" data-form-ldap-connector-target="urlCheckBind">
 <input type="hidden" value="{{ path('app_connector_ldap_check_user_filter', { 'domain' : connector.domain.id }) }}" data-form-ldap-connector-target="urlCheckUserFilter">
 <input type="hidden" value="{{ path('app_connector_ldap_check_groups_filter', { 'domain' : connector.domain.id }) }}" data-form-ldap-connector-target="urlCheckGroupFilter">
 
 <div class="row">
     <div class="col-md-12">
         <div class="form-group">
-            <label for="ldap_connector_name">{{ 'Entities.Connector.fields.name'|trans }}</label>
+            <label for="ldap_connector_name">
+                {{ 'Entities.Connector.fields.name'|trans }}
+            </label>
             {{ form_widget(form.name) }}
         </div>
     </div>
     <div class="col-md-6">
         <div class="form-group">
-            <label for="ldap_connector_ldapHost">{{ 'Entities.LdapConnector.fields.ldapHost'|trans }}</label>
-            {{ form_widget(form.ldapHost, { 'attr' : { 'data-form-ldap-connector-target' : 'ldapHost',  ' data-action' : 'blur->form-ldap-connector#checkConnection' }}) }}
+            <label for="ldap_connector_ldapHost">
+                {{ 'Entities.LdapConnector.fields.ldapHost'|trans }}
+            </label>
+            {{ form_widget(form.ldapHost, { 'attr' : { 'data-form-ldap-connector-target' : 'ldapHost',  ' data-action' : 'blur->form-ldap-connector#checkConnection' }}
+            ) }}
         </div>
     </div>
     <div class="col-md-6">
         <div class="form-group">
-            <label for="ldap_connector_ldapPort">{{ 'Entities.LdapConnector.fields.ldapPort'|trans }}</label>
-            {{ form_widget(form.ldapPort, { 'attr' : { 'data-form-ldap-connector-target' : 'ldapPort',  ' data-action' : 'blur->form-ldap-connector#checkConnection' }}) }}
+            <label for="ldap_connector_ldapPort">
+                {{ 'Entities.LdapConnector.fields.ldapPort'|trans }}
+            </label>
+            {{ form_widget(form.ldapPort, { 'attr' : { 'data-form-ldap-connector-target' : 'ldapPort',  ' data-action' : 'blur->form-ldap-connector#checkConnection' }}
+            ) }}
         </div>
     </div>
     <div class="col-md-10">
         <div class="form-group">
-            {{ form_widget(form.allowAnonymousBind, { 'attr' : { ' data-action' : 'click->form-ldap-connector#showHideBindInfoEventClick' }}) }}
+            {{ form_widget(form.allowAnonymousBind, { 'attr' : { ' data-action' : 'click->form-ldap-connector#showHideBindInfoEventClick' }}
+            ) }}
         </div>
     </div>
     <div class="col-md-2 pt-2 text-success text-center" data-form-ldap-connector-target="ldapBindResult"></div>
@@ -32,15 +42,21 @@
         <div class="row">
             <div class="col-md-5">
                 <div class="form-group">
-                    <label for="ldap_connector_ldapBindDn">{{ 'Entities.LdapConnector.fields.ldapBindDn'|trans }}</label>
-                    {{ form_widget(form.ldapBindDn, { 'attr' : { 'data-form-ldap-connector-target' : 'ldapBindDn',  ' data-action' : 'blur->form-ldap-connector#checkConnection' }}) }}
+                    <label for="ldap_connector_ldapBindDn">
+                        {{ 'Entities.LdapConnector.fields.ldapBindDn'|trans }}
+                    </label>
+                    {{ form_widget(form.ldapBindDn, { 'attr' : { 'data-form-ldap-connector-target' : 'ldapBindDn',  ' data-action' : 'blur->form-ldap-connector#checkConnection' }}
+                    ) }}
                 </div>
             </div>
             <div class="col-md-5">
                 <div class="form-group">
-                    <label for="ldap_connector_LdapPassword">{{ 'Entities.LdapConnector.fields.LdapPassword'|trans }}</label>
+                    <label for="ldap_connector_LdapPassword">
+                        {{ 'Entities.LdapConnector.fields.LdapPassword'|trans }}
+                    </label>
 
-                    {{ form_widget(form.LdapPassword, { 'attr' : { 'data-form-ldap-connector-target' : 'ldapPassword',  ' data-action' : 'blur->form-ldap-connector#checkConnection' }}) }}
+                    {{ form_widget(form.LdapPassword, { 'attr' : { 'data-form-ldap-connector-target' : 'ldapPassword',  ' data-action' : 'blur->form-ldap-connector#checkConnection' }}
+                    ) }}
                     <input type="hidden" name="encryptedPass" value="{{ connector.ldapPassword }}" data-form-ldap-connector-target="encryptedPass"/>
                 </div>
             </div>
@@ -49,64 +65,91 @@
     </div>
     <div class="col-md-12">
         <div class="form-group">
-            <label for="ldap_connector_LdapBaseDN">{{ 'Entities.LdapConnector.fields.LdapBaseDN'|trans }}</label>
+            <label for="ldap_connector_LdapBaseDN">
+                {{ 'Entities.LdapConnector.fields.LdapBaseDN'|trans }}
+            </label>
             {{ form_widget(form.LdapBaseDN) }}
         </div>
     </div>
     <div class="col-md-6">
         <div class="form-group">
-            <label for="ldap_connector_ldapRealNameField">{{ 'Entities.LdapConnector.fields.ldapRealNameField'|trans }}</label>
+            <label for="ldap_connector_ldapRealNameField">
+                {{ 'Entities.LdapConnector.fields.ldapRealNameField'|trans }}
+            </label>
             {{ form_widget(form.ldapRealNameField) }}
         </div>
     </div>
     <div class="col-md-6">
         <div class="form-group">
-            <label for="ldap_connector_ldapEmailField">{{ 'Entities.LdapConnector.fields.ldapEmailField'|trans }}</label>
+            <label for="ldap_connector_ldapEmailField">
+                {{ 'Entities.LdapConnector.fields.ldapEmailField'|trans }}
+            </label>
             {{ form_widget(form.ldapEmailField) }}
         </div>
     </div>
     <div class="col-md-6">
         <div class="form-group">
-            <label for="ldap_connector_ldapSharedWithField">{{ 'Entities.LdapConnector.fields.ldapSharedWithField'|trans }}</label>
+            <label for="ldap_connector_ldapSharedWithField">
+                {{ 'Entities.LdapConnector.fields.ldapSharedWithField'|trans }}
+            </label>
             {{ form_widget(form.ldapSharedWithField) }}
         </div>
     </div>
     <div class="col-md-6">
         <div class="form-group">
-            <label for="ldap_connector_ldapAliasField">{{ 'Entities.LdapConnector.fields.ldapAliasField'|trans }}</label>
+            <label for="ldap_connector_ldapAliasField">
+                {{ 'Entities.LdapConnector.fields.ldapAliasField'|trans }}
+            </label>
             {{ form_widget(form.ldapAliasField) }}
         </div>
     </div>
     <div class="col-md-12">
         <div class="form-group">
-            <label for="ldap_connector_ldapUserFilter">{{ 'Entities.LdapConnector.fields.ldapUserFilter'|trans }}</label>
-            {{ form_widget(form.ldapUserFilter, { 'attr' : { 'data-form-ldap-connector-target' : 'ldapUserFilter',  ' data-action' : 'blur->form-ldap-connector#checkUserFilter' }})  }}
+            <label for="ldap_connector_ldapUserFilter">
+                {{ 'Entities.LdapConnector.fields.ldapUserFilter'|trans }}
+            </label>
+            {{ form_widget(form.ldapUserFilter, { 'attr' : { 'data-form-ldap-connector-target' : 'ldapUserFilter',  ' data-action' : 'blur->form-ldap-connector#checkUserFilter' }}
+            )  }}
             <small class="d-none form-text text-muted"></small>
         </div>
     </div>
     <div class="col-md-12">
+        <label for="ldap_connector_targetGroups">
+            {{ 'Entities.Connector.fields.targetGroups'|trans }}
+        </label>
+        {{ form_widget(form.targetGroups) }}
+    </div>
+    <div class="col-md-12">
         <div class="form-group">
-            {{ form_widget(form.synchronizeGroup, { 'attr' : {'data-action' : 'click->form-ldap-connector#showHideGroupInfoEventClick' }}) }}
+            {{ form_widget(form.synchronizeGroup, { 'attr' : {'data-action' : 'click->form-ldap-connector#showHideGroupInfoEventClick' }}
+            ) }}
         </div>
         <fieldset id="info-group-ldap">
             <div class="row">
                 <div class="col-md-6">
                     <div class="form-group">
-                        <label for="ldap_connector_ldapGroupNameField">{{ 'Entities.LdapConnector.fields.ldapGroupNameField'|trans }}</label>
+                        <label for="ldap_connector_ldapGroupNameField">
+                            {{ 'Entities.LdapConnector.fields.ldapGroupNameField'|trans }}
+                        </label>
                         {{ form_widget(form.ldapGroupNameField) }}
                     </div>
                 </div>
                 <div class="col-md-12">
                     <div class="form-group">
-                        <label for="ldap_connector_ldapGroupMemberField">{{ 'Entities.LdapConnector.fields.ldapGroupMemberField'|trans }}</label>
+                        <label for="ldap_connector_ldapGroupMemberField">
+                            {{ 'Entities.LdapConnector.fields.ldapGroupMemberField'|trans }}
+                        </label>
                         {{ form_widget(form.ldapGroupMemberField) }}
                     </div>
                 </div>
 
                 <div class="col-md-12">
                     <div class="form-group">
-                        <label for="ldap_connector_ldapUserFilter">{{ 'Entities.LdapConnector.fields.ldapGroupFilter'|trans }}</label>
-                        {{ form_widget(form.ldapGroupFilter, { 'attr' : { 'data-form-ldap-connector-target' : 'ldapGroupFilter',  ' data-action' : 'blur->form-ldap-connector#checkGroupFilter' }})  }}
+                        <label for="ldap_connector_ldapUserFilter">
+                            {{ 'Entities.LdapConnector.fields.ldapGroupFilter'|trans }}
+                        </label>
+                        {{ form_widget(form.ldapGroupFilter, { 'attr' : { 'data-form-ldap-connector-target' : 'ldapGroupFilter',  ' data-action' : 'blur->form-ldap-connector#checkGroupFilter' }}
+                        )  }}
                         <small class="d-none form-text text-muted"></small>
                     </div>
                 </div>
@@ -118,7 +161,9 @@
 </div>
 {{ form_widget(form) }}
 <div class="d-flex justify-content-center">
-    <input type="submit" class="btn btn-primary mr-2" value="{{ button_label|default('Generics.actions.save'|trans)}}" >
-    <a class="btn btn-outline-secondary btn-close-modal" href="#">{{ 'Generics.actions.cancel'|trans() }}</a>
+    <input type="submit" class="btn btn-primary mr-2" value="{{ button_label|default('Generics.actions.save'|trans)}}">
+    <a class="btn btn-outline-secondary btn-close-modal" href="#">
+        {{ 'Generics.actions.cancel'|trans() }}
+    </a>
 </div>
 {{ form_end(form) }}

--- a/app/templates/connector/_form_ldap.html.twig
+++ b/app/templates/connector/_form_ldap.html.twig
@@ -1,169 +1,213 @@
 {{ form_start(form, { "attr" : {'data-controller' : 'form-ldap-connector'}}) }}
+    <input type="hidden" value="{{ path('app_connector_ldap_checkbind', { 'domain' : connector.domain.id }) }}" data-form-ldap-connector-target="urlCheckBind">
+    <input type="hidden" value="{{ path('app_connector_ldap_check_user_filter', { 'domain' : connector.domain.id }) }}" data-form-ldap-connector-target="urlCheckUserFilter">
+    <input type="hidden" value="{{ path('app_connector_ldap_check_groups_filter', { 'domain' : connector.domain.id }) }}" data-form-ldap-connector-target="urlCheckGroupFilter">
 
-<input type="hidden" value="{{ path('app_connector_ldap_checkbind', { 'domain' : connector.domain.id }) }}" data-form-ldap-connector-target="urlCheckBind">
-<input type="hidden" value="{{ path('app_connector_ldap_check_user_filter', { 'domain' : connector.domain.id }) }}" data-form-ldap-connector-target="urlCheckUserFilter">
-<input type="hidden" value="{{ path('app_connector_ldap_check_groups_filter', { 'domain' : connector.domain.id }) }}" data-form-ldap-connector-target="urlCheckGroupFilter">
+    <div class="row">
+        <div class="col-md-12">
+            <div class="form-group">
+                <label for="ldap_connector_name">
+                    {{ 'Entities.Connector.fields.name'|trans }}
+                </label>
+                {{ form_widget(form.name) }}
+            </div>
+        </div>
+    </div>
 
-<div class="row">
-    <div class="col-md-12">
-        <div class="form-group">
-            <label for="ldap_connector_name">
-                {{ 'Entities.Connector.fields.name'|trans }}
-            </label>
-            {{ form_widget(form.name) }}
+    <div class="row">
+        <div class="col-md-6">
+            <div class="form-group">
+                <label for="ldap_connector_ldapHost">
+                    {{ 'Entities.LdapConnector.fields.ldapHost'|trans }}
+                </label>
+                {{ form_widget(form.ldapHost, { 'attr' : { 'data-form-ldap-connector-target' : 'ldapHost',  ' data-action' : 'blur->form-ldap-connector#checkConnection' }}) }}
+            </div>
+        </div>
+
+        <div class="col-md-2">
+            <div class="form-group">
+                <label for="ldap_connector_ldapPort">
+                    {{ 'Entities.LdapConnector.fields.ldapPort'|trans }}
+                </label>
+                {{ form_widget(form.ldapPort, { 'attr' : { 'data-form-ldap-connector-target' : 'ldapPort',  ' data-action' : 'blur->form-ldap-connector#checkConnection' }}) }}
+            </div>
         </div>
     </div>
-    <div class="col-md-6">
-        <div class="form-group">
-            <label for="ldap_connector_ldapHost">
-                {{ 'Entities.LdapConnector.fields.ldapHost'|trans }}
-            </label>
-            {{ form_widget(form.ldapHost, { 'attr' : { 'data-form-ldap-connector-target' : 'ldapHost',  ' data-action' : 'blur->form-ldap-connector#checkConnection' }}
-            ) }}
-        </div>
-    </div>
-    <div class="col-md-6">
-        <div class="form-group">
-            <label for="ldap_connector_ldapPort">
-                {{ 'Entities.LdapConnector.fields.ldapPort'|trans }}
-            </label>
-            {{ form_widget(form.ldapPort, { 'attr' : { 'data-form-ldap-connector-target' : 'ldapPort',  ' data-action' : 'blur->form-ldap-connector#checkConnection' }}
-            ) }}
-        </div>
-    </div>
-    <div class="col-md-10">
-        <div class="form-group">
-            {{ form_widget(form.allowAnonymousBind, { 'attr' : { ' data-action' : 'click->form-ldap-connector#showHideBindInfoEventClick' }}
-            ) }}
-        </div>
-    </div>
-    <div class="col-md-2 pt-2 text-success text-center" data-form-ldap-connector-target="ldapBindResult"></div>
-    <div class="col-md-12" id="info-binding-ldap">
+
+    <fieldset>
+        <legend>
+            {{ 'Entities.LdapConnector.fields.connectionInformation' | trans }}
+        </legend>
+
         <div class="row">
-            <div class="col-md-5">
+            <div class="col-md-10">
+                <div class="form-group">
+                    {{ form_widget(form.allowAnonymousBind, { 'attr' : { ' data-action' : 'click->form-ldap-connector#showHideBindInfoEventClick' }}) }}
+                </div>
+            </div>
+
+            <div class="col-md-2 pt-2 text-success text-center" data-form-ldap-connector-target="ldapBindResult"></div>
+        </div>
+
+        <div class="row" id="info-binding-ldap">
+            <div class="col-md-6">
                 <div class="form-group">
                     <label for="ldap_connector_ldapBindDn">
                         {{ 'Entities.LdapConnector.fields.ldapBindDn'|trans }}
                     </label>
-                    {{ form_widget(form.ldapBindDn, { 'attr' : { 'data-form-ldap-connector-target' : 'ldapBindDn',  ' data-action' : 'blur->form-ldap-connector#checkConnection' }}
-                    ) }}
+                    {{ form_widget(form.ldapBindDn, { 'attr' : { 'data-form-ldap-connector-target' : 'ldapBindDn',  ' data-action' : 'blur->form-ldap-connector#checkConnection' }}) }}
                 </div>
             </div>
-            <div class="col-md-5">
+
+            <div class="col-md-6">
                 <div class="form-group">
                     <label for="ldap_connector_LdapPassword">
                         {{ 'Entities.LdapConnector.fields.LdapPassword'|trans }}
                     </label>
 
-                    {{ form_widget(form.LdapPassword, { 'attr' : { 'data-form-ldap-connector-target' : 'ldapPassword',  ' data-action' : 'blur->form-ldap-connector#checkConnection' }}
-                    ) }}
+                    {{ form_widget(form.LdapPassword, { 'attr' : { 'data-form-ldap-connector-target' : 'ldapPassword',  ' data-action' : 'blur->form-ldap-connector#checkConnection' }}) }}
                     <input type="hidden" name="encryptedPass" value="{{ connector.ldapPassword }}" data-form-ldap-connector-target="encryptedPass"/>
                 </div>
             </div>
+        </div>
 
-        </div>
-    </div>
-    <div class="col-md-12">
-        <div class="form-group">
-            <label for="ldap_connector_LdapBaseDN">
-                {{ 'Entities.LdapConnector.fields.LdapBaseDN'|trans }}
-            </label>
-            {{ form_widget(form.LdapBaseDN) }}
-        </div>
-    </div>
-    <div class="col-md-6">
-        <div class="form-group">
-            <label for="ldap_connector_ldapRealNameField">
-                {{ 'Entities.LdapConnector.fields.ldapRealNameField'|trans }}
-            </label>
-            {{ form_widget(form.ldapRealNameField) }}
-        </div>
-    </div>
-    <div class="col-md-6">
-        <div class="form-group">
-            <label for="ldap_connector_ldapEmailField">
-                {{ 'Entities.LdapConnector.fields.ldapEmailField'|trans }}
-            </label>
-            {{ form_widget(form.ldapEmailField) }}
-        </div>
-    </div>
-    <div class="col-md-6">
-        <div class="form-group">
-            <label for="ldap_connector_ldapSharedWithField">
-                {{ 'Entities.LdapConnector.fields.ldapSharedWithField'|trans }}
-            </label>
-            {{ form_widget(form.ldapSharedWithField) }}
-        </div>
-    </div>
-    <div class="col-md-6">
-        <div class="form-group">
-            <label for="ldap_connector_ldapAliasField">
-                {{ 'Entities.LdapConnector.fields.ldapAliasField'|trans }}
-            </label>
-            {{ form_widget(form.ldapAliasField) }}
-        </div>
-    </div>
-    <div class="col-md-12">
-        <div class="form-group">
-            <label for="ldap_connector_ldapUserFilter">
-                {{ 'Entities.LdapConnector.fields.ldapUserFilter'|trans }}
-            </label>
-            {{ form_widget(form.ldapUserFilter, { 'attr' : { 'data-form-ldap-connector-target' : 'ldapUserFilter',  ' data-action' : 'blur->form-ldap-connector#checkUserFilter' }}
-            )  }}
-            <small class="d-none form-text text-muted"></small>
-        </div>
-    </div>
-    <div class="col-md-12">
-        <label for="ldap_connector_targetGroups">
-            {{ 'Entities.Connector.fields.targetGroups'|trans }}
-        </label>
-        {{ form_widget(form.targetGroups) }}
-    </div>
-    <div class="col-md-12">
-        <div class="form-group">
-            {{ form_widget(form.synchronizeGroup, { 'attr' : {'data-action' : 'click->form-ldap-connector#showHideGroupInfoEventClick' }}
-            ) }}
-        </div>
-        <fieldset id="info-group-ldap">
-            <div class="row">
-                <div class="col-md-6">
-                    <div class="form-group">
-                        <label for="ldap_connector_ldapGroupNameField">
-                            {{ 'Entities.LdapConnector.fields.ldapGroupNameField'|trans }}
-                        </label>
-                        {{ form_widget(form.ldapGroupNameField) }}
-                    </div>
-                </div>
-                <div class="col-md-12">
-                    <div class="form-group">
-                        <label for="ldap_connector_ldapGroupMemberField">
-                            {{ 'Entities.LdapConnector.fields.ldapGroupMemberField'|trans }}
-                        </label>
-                        {{ form_widget(form.ldapGroupMemberField) }}
-                    </div>
-                </div>
-
-                <div class="col-md-12">
-                    <div class="form-group">
-                        <label for="ldap_connector_ldapUserFilter">
-                            {{ 'Entities.LdapConnector.fields.ldapGroupFilter'|trans }}
-                        </label>
-                        {{ form_widget(form.ldapGroupFilter, { 'attr' : { 'data-form-ldap-connector-target' : 'ldapGroupFilter',  ' data-action' : 'blur->form-ldap-connector#checkGroupFilter' }}
-                        )  }}
-                        <small class="d-none form-text text-muted"></small>
-                    </div>
+        <div class="row">
+            <div class="col-md-12">
+                <div class="form-group">
+                    <label for="ldap_connector_LdapBaseDN">
+                        {{ 'Entities.LdapConnector.fields.LdapBaseDN'|trans }}
+                    </label>
+                    {{ form_widget(form.LdapBaseDN) }}
                 </div>
             </div>
-        </fieldset>
+        </div>
+    </fieldset>
+
+    <fieldset>
+        <legend>
+            {{ 'Entities.LdapConnector.fields.usersInformation' | trans }}
+        </legend>
+
+        <div class="row">
+            <div class="col-md-12">
+                <div class="form-group">
+                    <label for="ldap_connector_ldapUserFilter">
+                        {{ 'Entities.LdapConnector.fields.ldapUserFilter'|trans }}
+                    </label>
+                    {{ form_widget(form.ldapUserFilter, { 'attr' : { 'data-form-ldap-connector-target' : 'ldapUserFilter',  ' data-action' : 'blur->form-ldap-connector#checkUserFilter' }})  }}
+                    <small class="d-none form-text text-muted"></small>
+                </div>
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="col-md-6">
+                <div class="form-group">
+                    <label for="ldap_connector_ldapRealNameField">
+                        {{ 'Entities.LdapConnector.fields.ldapRealNameField'|trans }}
+                    </label>
+                    {{ form_widget(form.ldapRealNameField) }}
+                </div>
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="col-md-6">
+                <div class="form-group">
+                    <label for="ldap_connector_ldapEmailField">
+                        {{ 'Entities.LdapConnector.fields.ldapEmailField'|trans }}
+                    </label>
+                    {{ form_widget(form.ldapEmailField) }}
+                </div>
+            </div>
+
+            <div class="col-md-6">
+                <div class="form-group">
+                    <label for="ldap_connector_ldapAliasField">
+                        {{ 'Entities.LdapConnector.fields.ldapAliasField'|trans }}
+                    </label>
+                    {{ form_widget(form.ldapAliasField) }}
+                </div>
+            </div>
+        </div>
+    </fieldset>
+
+    <fieldset>
+        <legend>
+            {{ 'Entities.LdapConnector.fields.advancedOptions' | trans }}
+        </legend>
+
+        <div class="row">
+            <div class="col-md-12">
+                <label for="ldap_connector_targetGroups">
+                    {{ 'Entities.Connector.fields.targetGroups'|trans }}
+                </label>
+                {{ form_widget(form.targetGroups) }}
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="col-md-12">
+                <div class="form-group">
+                    <label for="ldap_connector_ldapSharedWithField">
+                        {{ 'Entities.LdapConnector.fields.ldapSharedWithField'|trans }}
+                    </label>
+                    {{ form_widget(form.ldapSharedWithField) }}
+                </div>
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="col-md-12">
+                <div class="form-group">
+                    {{ form_widget(form.synchronizeGroup, { 'attr' : {'data-action' : 'click->form-ldap-connector#showHideGroupInfoEventClick' }}) }}
+                </div>
+
+                <fieldset id="info-group-ldap">
+                    <div class="row">
+                        <div class="col-md-12">
+                            <div class="form-group">
+                                <label for="ldap_connector_ldapUserFilter">
+                                    {{ 'Entities.LdapConnector.fields.ldapGroupFilter'|trans }}
+                                </label>
+                                {{ form_widget(form.ldapGroupFilter, { 'attr' : { 'data-form-ldap-connector-target' : 'ldapGroupFilter',  ' data-action' : 'blur->form-ldap-connector#checkGroupFilter' }})  }}
+                                <small class="d-none form-text text-muted"></small>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="row">
+                        <div class="col-md-12">
+                            <div class="form-group">
+                                <label for="ldap_connector_ldapGroupNameField">
+                                    {{ 'Entities.LdapConnector.fields.ldapGroupNameField'|trans }}
+                                </label>
+                                {{ form_widget(form.ldapGroupNameField) }}
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="row">
+                        <div class="col-md-12">
+                            <div class="form-group">
+                                <label for="ldap_connector_ldapGroupMemberField">
+                                    {{ 'Entities.LdapConnector.fields.ldapGroupMemberField'|trans }}
+                                </label>
+                                {{ form_widget(form.ldapGroupMemberField) }}
+                            </div>
+                        </div>
+                    </div>
+                </fieldset>
+            </div>
+        </div>
+    </fieldset>
+
+    {{ form_widget(form) }}
+
+    <div class="d-flex justify-content-center">
+        <input type="submit" class="btn btn-primary mr-2" value="{{ button_label|default('Generics.actions.save'|trans)}}">
+        <a class="btn btn-outline-secondary btn-close-modal" href="#">
+            {{ 'Generics.actions.cancel'|trans() }}
+        </a>
     </div>
-
-
-</div>
-{{ form_widget(form) }}
-<div class="d-flex justify-content-center">
-    <input type="submit" class="btn btn-primary mr-2" value="{{ button_label|default('Generics.actions.save'|trans)}}">
-    <a class="btn btn-outline-secondary btn-close-modal" href="#">
-        {{ 'Generics.actions.cancel'|trans() }}
-    </a>
-</div>
 {{ form_end(form) }}

--- a/app/translations/messages.en.yml
+++ b/app/translations/messages.en.yml
@@ -606,6 +606,7 @@ Entities:
       name: "Connector name"
       type: "Connector type"
       active: "Active connector"
+      targetGroups: "Assign user(s) to group(s)"
     actions:
       add: "Add Office365 connector"
       edit: "Edit Office365 connector"

--- a/app/translations/messages.en.yml
+++ b/app/translations/messages.en.yml
@@ -616,11 +616,13 @@ Entities:
       add: "Add LDAP connector"
       edit: "Edit LDAP connector"
     fields:
+      advancedOptions: "Advanced options"
+      connectionInformation: "Connection information"
       ldapHost: "Host"
       ldapPort: "Port (default 389)"
       allowAnonymousBind: "Anonymous connection"
-      LdapBaseDN: "BaseDN"
-      ldapBindDn: "Bind Dn"
+      LdapBaseDN: "Base DN"
+      ldapBindDn: "Bind DN"
       LdapPassword: "Password"
       ldapRealNameField: "LDAP field for username (ex: sn)"
       synchronizeGroup: "Also synchronize groups"
@@ -631,6 +633,7 @@ Entities:
       ldapGroupMemberField: "LDAP field for group members"
       ldapUserFilter: "Filter for users"
       ldapGroupFilter: "Filter for groups"
+      usersInformation: "Users information"
   ImapConnector:
     labels:
     actions:

--- a/app/translations/messages.fr.yml
+++ b/app/translations/messages.fr.yml
@@ -606,6 +606,7 @@ Entities:
       name: "Nom du connecteur"
       type: "Type de connecteur"
       active: "Connecteur actif"
+      targetGroups: "Affecter les utilisateurs au(x) groupe(s)"
     actions:
       add: "Ajouter un connecteur Office365"
       edit: "Modifier un connecteur Office365"

--- a/app/translations/messages.fr.yml
+++ b/app/translations/messages.fr.yml
@@ -616,11 +616,13 @@ Entities:
       add: "Ajouter un connecteur LDAP"
       edit: "Modifier le connecteur LDAP"
     fields:
+      advancedOptions: "Options avancées"
+      connectionInformation: "Informations de connexion"
       ldapHost: "Hôte"
       ldapPort: "Port (défaut 389)"
       allowAnonymousBind: "Connexion anonyme"
-      LdapBaseDN: "BaseDN"
-      ldapBindDn: "Bind Dn"
+      LdapBaseDN: "Base DN"
+      ldapBindDn: "Bind DN"
       LdapPassword: "Mot de passe"
       ldapRealNameField: "Champ LDAP pour le nom (ex : sn)"
       synchronizeGroup: "Synchronisez également les groupes"
@@ -631,6 +633,7 @@ Entities:
       ldapGroupMemberField: "Champ LDAP pour les utilisateurs du groupe"
       ldapUserFilter: "Filtre pour les utilisateurs"
       ldapGroupFilter: "Filtre pour les groupes"
+      usersInformation: "Informations utilisateurs"
   ImapConnector:
     labels:
     actions:


### PR DESCRIPTION
## Related issue(s)
https://github.com/Probesys/agentj/issues/261

## How to test manually
- [x] Create a domain example.com
- [x] Create 2 active groups for this domain

- The first one - group1 - with "Allow all emails" as default rule and priority 1
- The second one - group2 - with "Block all emails" as default rule and priority 2

- [x] Create an LDAP connector [following the doc](https://github.com/Probesys/agentj/blob/261-ldap-allow-to-attach-imported-users-to-one-or-more-groups/docs/developers/ldap.md), and select those 2 groups to attach imported users.
- [x] Import the user from this connector
- [x] Got to User -> Email accounts and ensure that imported users are attached to the groups
- [x] Go to Authorized sender and ensure a rule "@." exists. do the same for group 2

## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works on both Firefox and Chrome
- [x] Tests are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
