### PR TITLE
Fix (impersonation) button not showing original user after session expiry (#269)

### DIFF
--- a/app/src/Security/LoginFormAuthenticator.php
+++ b/app/src/Security/LoginFormAuthenticator.php
@@ -166,7 +166,6 @@ class LoginFormAuthenticator extends AbstractLoginFormAuthenticator
     {
         /** @var User $user */
         $user = $token->getUser();
-        $request->getSession()->set('originalUser', $user->getUsername());
 
         if ($user->getDomain() && $user->getDomain()->getDefaultLang()) {
             $request->getSession()->set('_locale', $user->getDomain()->getDefaultLang());

--- a/app/templates/header.html.twig
+++ b/app/templates/header.html.twig
@@ -1,80 +1,92 @@
 {% if logoUploaded %}
-	{% set logoPath = asset('files/upload/') ~ logoImg %}
+    {% set logoPath = asset('files/upload/') ~ logoImg %}
 {% else %}
-	{% set logoPath = asset('img/') ~ logoImg %}
+    {% set logoPath = asset('img/') ~ logoImg %}
 {% endif %}
+
 <nav id="topnav" class="navbar navbar-expand  bg-white fixed-top">
-	<a class="navbar-brand mr-1" href="#sidebar" data-turbo="false" id="toggle-sidebar">
-		<i class="fas fa-bars fa-lg"></i>
-	</a>
-	{% if is_granted('ROLE_ADMIN') %}
-		<a class="ml-2 btn" href="{{ path('advanced_search') }}" data-turbo="false">
-			<i class="fa fa-search" aria-hidden="true"></i>
-		</a>
-	{% endif %}
-	<a class="navbar-brand m-auto" href="{{ path('homepage') }}">
-		<img src="{{ logoPath }}" class="logo">
-	</a>
+    <a class="navbar-brand mr-1" href="#sidebar" data-turbo="false" id="toggle-sidebar">
+        <i class="fas fa-bars fa-lg"></i>
+    </a>
 
-	<div class="d-md-inline-block">
-		<ul class="navbar-nav ml-auto ml-md-0">
-			<li class="nav-item ">
-				<a href="mailto:support@probesys.coop" class="nav-link">
-					<i class="fas fa-ambulance text-success">&nbsp;</i>
-				</a>
-			</li>
-			{% if locales|length > 1 %}
-				<li class="nav-item dropdown no-arrow mx-1">
-					<a data-turbo="false" class="nav-link dropdown-toggle" href="#" id="alertsDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-						<i class="far fa-flag"></i>
-						<span class="libelle">&nbsp;{{ app.request.getLocale()|upper }}</span>
-					</i>
-					</a>
-					<div class="dropdown-menu dropdown-menu-right">
-						{% for locale in locales %}
-							<a class="dropdown-item {% if locale == app.request.locale %}active{% endif %}" data-turbo="false" href="{{ path('setlocale', {'language': locale}) }}">{{locale|upper}}</a>
-						{% endfor %}
-					</div>					
-				</li>
-			
-		</li>
+    {% if is_granted('ROLE_ADMIN') %}
+        <a class="ml-2 btn" href="{{ path('advanced_search') }}" data-turbo="false">
+            <i class="fa fa-search" aria-hidden="true"></i>
+        </a>
+    {% endif %}
 
-	</li>
+    <a class="navbar-brand m-auto" href="{{ path('homepage') }}">
+        <img src="{{ logoPath }}" class="logo">
+    </a>
 
+    <div class="d-md-inline-block">
+        <ul class="navbar-nav ml-auto ml-md-0">
+            <li class="nav-item ">
+                <a href="mailto:support@probesys.coop" class="nav-link">
+                    <i class="fas fa-ambulance text-success">&nbsp;</i>
+                </a>
+            </li>
 
+            {% if locales|length > 1 %}
+                <li class="nav-item dropdown no-arrow mx-1">
+                    <a data-turbo="false" class="nav-link dropdown-toggle" href="#" id="alertsDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                        <i class="far fa-flag"></i>
+                        <span class="libelle">&nbsp;{{ app.request.getLocale()|upper }}</span>
+                    </a>
 
-{% endif %}
-<li class="nav-item dropdown no-arrow">
-	<a data-turbo="false" class="nav-link dropdown-toggle font-weight-bolder d-none d-md-block" href="#" id="userDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-		{{app.user.username}}
-	</a>
-	<a data-turbo="false" class="nav-link dropdown-toggle font-weight-bolder d-block d-sm-none" href="#" id="userDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-		@
-	</a>
-	<div class="dropdown-menu dropdown-menu-right " aria-labelledby="userDropdown">
-		{% if not is_granted('ROLE_ADMIN') %}
-			<a class="dropdown-item" href="{{path('account')}}">
-				<i class="fas fa-user-circle"></i>
-				{{'Navigation.user_profil'|trans}}</a>
-			<div class="dropdown-divider"></div>
-		{% endif %}
-		{% if is_granted('IS_IMPERSONATOR') %}
-			<a class="dropdown-item" href="{{ path('homepage', {'_switch_user': '_exit'}) }}">&nbsp;<i class="fas fa-random"></i>
-				{{'Generics.actions.exitImpersonation'|trans}}
-				{{ app.session.get('originalUser') }}</a>
-			<div class="dropdown-divider"></div>
-		{% endif %}
-		{% if sharedBoxes|length > 0%}
-			<div class="dropdown-header">Autres boîtes mails</div>
-			{% for sharedBox in sharedBoxes %}
-				<a class="dropdown-item" href="{{ path('homepage', {'_switch_user': sharedBox.username}) }}" title="{{ 'Generics.actions.connectAs'|trans() ~ sharedBox.username}}">
-					<i class="fas fa-envelope"></i>
-					{{ sharedBox.username }}</a>
-			{% endfor %}
-			<div class="dropdown-divider"></div>
-		{% endif %}
-		<a class="dropdown-item" href="{{path('app_logout')}}">
-			<i class="fas fa-sign-out-alt fa-fw"></i>
-			{{'Navigation.logout'|trans}}</a>
-	</div>
-</li></ul></div></nav>
+                    <div class="dropdown-menu dropdown-menu-right">
+                        {% for locale in locales %}
+                            <a class="dropdown-item {% if locale == app.request.locale %}active{% endif %}" data-turbo="false" href="{{ path('setlocale', {'language': locale}) }}">
+                                {{locale|upper}}
+                            </a>
+                        {% endfor %}
+                    </div>
+                </li>
+            {% endif %}
+
+            <li class="nav-item dropdown no-arrow">
+                <a data-turbo="false" class="nav-link dropdown-toggle font-weight-bolder d-none d-md-block" href="#" id="userDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                    {{app.user.username}}
+                </a>
+
+                <div class="dropdown-menu dropdown-menu-right " aria-labelledby="userDropdown">
+                    {% if not is_granted('ROLE_ADMIN') %}
+                        <a class="dropdown-item" href="{{path('account')}}">
+                            <i class="fas fa-user-circle"></i>
+                            {{'Navigation.user_profil'|trans}}
+                        </a>
+
+                        <div class="dropdown-divider"></div>
+                    {% endif %}
+
+                    {% if is_granted('IS_IMPERSONATOR') %}
+                        <a class="dropdown-item" href="{{ path('homepage', {'_switch_user': '_exit'}) }}">&nbsp;<i class="fas fa-random"></i>
+                            {{'Generics.actions.exitImpersonation'|trans}}
+                            {{ app.session.get('originalUser') }}
+                        </a>
+
+                        <div class="dropdown-divider"></div>
+                    {% endif %}
+
+                    {% if sharedBoxes|length > 0%}
+                        <div class="dropdown-header">Autres boîtes mails</div>
+
+                        {% for sharedBox in sharedBoxes %}
+                            <a class="dropdown-item" href="{{ path('homepage', {'_switch_user': sharedBox.username}) }}" title="{{ 'Generics.actions.connectAs'|trans() ~ sharedBox.username}}">
+                                <i class="fas fa-envelope"></i>
+                                {{ sharedBox.username }}
+                            </a>
+                        {% endfor %}
+
+                        <div class="dropdown-divider"></div>
+                    {% endif %}
+
+                    <a class="dropdown-item" href="{{path('app_logout')}}">
+                        <i class="fas fa-sign-out-alt fa-fw"></i>
+                        {{'Navigation.logout'|trans}}
+                    </a>
+                </div>
+            </li>
+        </ul>
+    </div>
+</nav>

--- a/app/templates/header.html.twig
+++ b/app/templates/header.html.twig
@@ -59,10 +59,12 @@
                         <div class="dropdown-divider"></div>
                     {% endif %}
 
-                    {% if is_granted('IS_IMPERSONATOR') %}
-                        <a class="dropdown-item" href="{{ path('homepage', {'_switch_user': '_exit'}) }}">&nbsp;<i class="fas fa-random"></i>
+                    {% set originalUser = get_original_user() %}
+                    {% if originalUser %}
+                        <a class="dropdown-item" href="{{ path('homepage', {'_switch_user': '_exit'}) }}">
+                            <i class="fas fa-random"></i>
                             {{'Generics.actions.exitImpersonation'|trans}}
-                            {{ app.session.get('originalUser') }}
+                            {{ originalUser.username }}
                         </a>
 
                         <div class="dropdown-divider"></div>


### PR DESCRIPTION
## Related issue(s)
<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

Fix the "Back to [user]" button displaying empty or "[life]" 
after session expiration during user impersonation.

Closes https://github.com/Probesys/agentj/issues/269

- Replace session-based storage with security token retrieval
- Add get_original_user() Twig function using SwitchUserToken
- Update header template to use new Twig function

## How to test manually
<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Login as admin
2. Delete the `PHPSESSID` cookie in developers tool
3. Impersonate a user
4. Open the user menu
5. Verify that the "back to user" button is showing the admin username

## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works on both Firefox and Chrome
- [x] Tests are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
