### PR TITLE
feat: Hide the local login form when OAuth2 is enabled

### DIFF
--- a/app/src/Controller/SecurityController.php
+++ b/app/src/Controller/SecurityController.php
@@ -5,6 +5,7 @@ namespace App\Controller;
 use App\Repository\UserRepository;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
@@ -12,24 +13,28 @@ use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
 class SecurityController extends AbstractController
 {
     #[Route(path: '/login', name: 'app_login')]
-    public function login(AuthenticationUtils $authenticationUtils): Response
+    public function login(Request $request, AuthenticationUtils $authenticationUtils): Response
     {
-      // get the login error if there is one
         if ($this->getUser()) {
             return new RedirectResponse($this->container->get('router')->generate('homepage'));
         }
+
+        // Get the login error if any.
         $error = $authenticationUtils->getLastAuthenticationError();
-      // last username entered by the user
+
+        // Get the last username entered by the user.
         $lastUsername = $authenticationUtils->getLastUsername();
-        $logoUploaded = file_exists($this->getParameter('app.upload_directory') . 'logo.png');
+
+        // This is used when OAuth SSO is enabled, to let the administrators to
+        // access the local login form.
+        $forceDisplayForm = $request->query->getBoolean('local');
+
         return $this->render('security/login.html.twig', [
-                'last_username' => $lastUsername,
-                'error' => $error,
-                'logoUploaded' => $logoUploaded
+            'last_username' => $lastUsername,
+            'error' => $error,
+            'force_display_form' => $forceDisplayForm,
         ]);
     }
-
-
 
     #[Route(path: '/logout', name: 'app_logout')]
     public function logout(): RedirectResponse

--- a/app/templates/security/login.html.twig
+++ b/app/templates/security/login.html.twig
@@ -5,58 +5,57 @@
 {% block body %}
     <div class="h-100">
         <div class="col-lg-4 col-md-6 col-sm-12 text-center pb-4 m-auto login">
-            <form method="post" name="login_form" id="login_form" data-controller="login">
-                {% if error %}
-                    <div class="alert alert-danger">{{ error.messageKey|trans(error.messageData, 'security') }}</div>
-                {% endif %}
+            <div class="mb-3"><img class="logo" src="{{ asset('img/agent-j-logo-desktop.svg') }}" /></div>
 
-                {% for label, messages in app.flashes %}
-                    {% for message in messages %}
-                        <div class="alert alert-danger">{{ message | trans }}</div>
-                    {% endfor %}
-                {% endfor %}
+            <h1 class="mb-5 font-weight-bolder">{{ 'Generics.messages.welcomeHomeMessage'|trans|raw }}</h1>
 
-                <div class="mb-3"><img class="logo" src="{{ asset('img/agent-j-logo-desktop.svg') }}" /></div>
-
-                <h1 class="mb-5 font-weight-bolder">{{ 'Generics.messages.welcomeHomeMessage'|trans|raw }}</h1>
-
-                <div class="form-group">
-                    <label for="inputUsername" class="sr-only">{{ 'Entities.User.fields.userName'|trans }}</label>
-                    <input type="text" value="{{ last_username }}" name="username" id="inputUsername" class="form-control" placeholder="{{ 'Entities.User.fields.userName'|trans }}" required autofocus autocapitalize="none"/>
-                </div>
-
-                <div class="form-group">
-                    <label for="inputPassword" class="sr-only">{{ 'Entities.User.fields.password'|trans }}</label>
-                    <input type="password" name="password" id="inputPassword" class="form-control" placeholder="{{ 'Entities.User.fields.password'|trans }}" required>
-                </div>
-
-                <button class="btn btn-lg btn-primary" type="submit" name="loginBtn" id="loginBtn">
-                    {{ 'Generics.actions.impersonate'|trans }}
-                </button>
-
-                <div class="icheck-primary">
-                    <input type="checkbox" id="remember_me" name="_remember_me">
-                    <label for="remember_me">
-                        {{ 'Generics.actions.rememberme'|trans }}
-                    </label>
-                </div>
-
-                <input type="hidden" name="_csrf_token" value="{{ csrf_token('authenticate') }}">
-            </form>
-
-            {% if oauth_enabled %}
-                <div>
-                    <a class="btn btn-outline-secondary" href="{{ path('connect_oauth_start') }}">
+            {% if not force_display_form and (oauth_enabled or azure_oauth_enabled) %}
+                {% if oauth_enabled %}
+                    <a class="btn btn-primary" href="{{ path('connect_oauth_start') }}">
+                        <i class="fas fa-sign-in-alt"></i>
                         {{ oauth_login_label }}
                     </a>
-                </div>
-            {% elseif azure_oauth_enabled %}
-                <div>
-                    <a class="btn btn-outline-secondary" href="{{ path('connect_azure_start') }}">
+                {% elseif azure_oauth_enabled %}
+                    <a class="btn btn-primary" href="{{ path('connect_azure_start') }}">
                         <i class="fab fa-microsoft"></i>
                         {{ 'Generics.actions.connectWithMicrosoft' | trans }}
                     </a>
-                </div>
+                {% endif %}
+            {% else %}
+                <form method="post" name="login_form" id="login_form" data-controller="login">
+                    {% if error %}
+                        <div class="alert alert-danger">{{ error.messageKey|trans(error.messageData, 'security') }}</div>
+                    {% endif %}
+
+                    {% for label, messages in app.flashes %}
+                        {% for message in messages %}
+                            <div class="alert alert-danger">{{ message | trans }}</div>
+                        {% endfor %}
+                    {% endfor %}
+
+                    <div class="form-group">
+                        <label for="inputUsername" class="sr-only">{{ 'Entities.User.fields.userName'|trans }}</label>
+                        <input type="text" value="{{ last_username }}" name="username" id="inputUsername" class="form-control" placeholder="{{ 'Entities.User.fields.userName'|trans }}" required autofocus autocapitalize="none"/>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="inputPassword" class="sr-only">{{ 'Entities.User.fields.password'|trans }}</label>
+                        <input type="password" name="password" id="inputPassword" class="form-control" placeholder="{{ 'Entities.User.fields.password'|trans }}" required>
+                    </div>
+
+                    <button class="btn btn-lg btn-primary" type="submit" name="loginBtn" id="loginBtn">
+                        {{ 'Generics.actions.impersonate'|trans }}
+                    </button>
+
+                    <div class="icheck-primary">
+                        <input type="checkbox" id="remember_me" name="_remember_me">
+                        <label for="remember_me">
+                            {{ 'Generics.actions.rememberme'|trans }}
+                        </label>
+                    </div>
+
+                    <input type="hidden" name="_csrf_token" value="{{ csrf_token('authenticate') }}">
+                </form>
             {% endif %}
         </div>
     </div>

--- a/docs/administrators/oauth2.md
+++ b/docs/administrators/oauth2.md
@@ -5,6 +5,13 @@ AgentJ allows your users to login with your SSO through the OAuth2 protocol.
 > [!NOTE]
 > The users must exist in the database first in order to be able to login.
 
+## Information about the local login form
+
+When OAuth2 is enabled, the default form is removed from the login page.
+However, administrators may still need to login with this form.
+
+**To access the local login form, add the `local=true` parameter to the login URL, e.g. `https://agentj.example.com/login?local=true`**
+
 ## Setup your OAuth server
 
 Before enabling OAuth in AgentJ, you need to declare a new application on your OAuth server.


### PR DESCRIPTION
This clarifies the login workflow for standard users. Administrators still can to login with the local form by adding the `local=true` parameter to the login URL.

## Related issue(s)
<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

N/A

## How to test manually
<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Setup OAuth2 (just set `ENABLE_OAUTH=false`, don't worry about the client id/secret/endpoints)
2. Go to the login page http://localhost:8090/login
3. Verify that only the SSO login button is displayed
4. Go to http://localhost:8090/login?local=true
5. Verify that the local form is displayed and that you can login

## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works on both Firefox and Chrome
- [x] Tests are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
