### PR TITLE
Ajout d'un script de test -  Modification Command TruncateOldMessage

### DIFF
--- a/app/src/Repository/MsgsRepository.php
+++ b/app/src/Repository/MsgsRepository.php
@@ -219,22 +219,12 @@ class MsgsRepository extends BaseMessageRepository
      *
      * @return array{
      *     nbDeletedMsgs: int,
-     *     nbDeletedMsgrcpt: int,
      *     nbDeletedQuarantine: int,
      * }
      */
     public function truncateMessageOlder(int $date): array
     {
         $conn = $this->getEntityManager()->getConnection();
-
-        $sql = ' DELETE mr FROM msgrcpt mr '
-            . ' LEFT JOIN  msgs m ON m.mail_id = mr.mail_id '
-            . ' WHERE m.time_num < :date';
-
-        $stmt = $conn->prepare($sql);
-        $stmt->bindValue('date', $date, DBAL\ParameterType::INTEGER);
-        $result = $stmt->executeQuery();
-        $nbDeletedMsgrcpt = $result->rowCount();
 
         $sql = ' DELETE q FROM quarantine q '
             . ' LEFT JOIN  msgs m ON m.mail_id = q.mail_id '
@@ -254,7 +244,6 @@ class MsgsRepository extends BaseMessageRepository
 
         return [
             'nbDeletedMsgs' => $nbDeletedMsgs,
-            'nbDeletedMsgrcpt' => $nbDeletedMsgrcpt,
             'nbDeletedQuarantine' => $nbDeletedQuarantine,
         ];
     }

--- a/app/src/Repository/OutMsgRepository.php
+++ b/app/src/Repository/OutMsgRepository.php
@@ -3,6 +3,7 @@
 namespace App\Repository;
 
 use App\Entity\OutMsg;
+use Doctrine\DBAL;
 use Doctrine\Persistence\ManagerRegistry;
 
 /**
@@ -13,5 +14,39 @@ class OutMsgRepository extends BaseMessageRepository
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, OutMsg::class);
+    }
+
+    /**
+     * Delete outgoing messages older than $date
+     *
+     * @return array{
+     *     nbDeletedMsgs: int,
+     *     nbDeletedQuarantine: int,
+     * }
+     */
+    public function truncateMessageOlder(int $date): array
+    {
+        $conn = $this->getEntityManager()->getConnection();
+
+        $sql = ' DELETE q FROM out_quarantine q '
+            . ' LEFT JOIN  out_msgs m ON m.mail_id = q.mail_id '
+            . ' WHERE m.time_num < :date';
+
+        $stmt = $conn->prepare($sql);
+        $stmt->bindValue('date', $date, DBAL\ParameterType::INTEGER);
+        $result = $stmt->executeQuery();
+        $nbDeletedQuarantine = $result->rowCount();
+
+        $sql = ' DELETE FROM out_msgs WHERE time_num < :date';
+
+        $stmt = $conn->prepare($sql);
+        $stmt->bindValue('date', $date, DBAL\ParameterType::INTEGER);
+        $result = $stmt->executeQuery();
+        $nbDeletedMsgs = $result->rowCount();
+
+        return [
+            'nbDeletedMsgs' => $nbDeletedMsgs,
+            'nbDeletedQuarantine' => $nbDeletedQuarantine,
+        ];
     }
 }


### PR DESCRIPTION
## Related issue(s)
https://github.com/Probesys/agentj/issues/285

## How to test manually

I didn't really know how to make old email appear so I create a small script to help me test, I didn't use fixture since it would have been less flexible, I pushed the script but if there is no re-usability it can be drop

```
# 1. Create 5 young messages (5 days old)
bash scripts/create_test_mail.sh --type MSGS --count 5 --days-old 5

# 2. Create 10 old messages (45 days old)
bash scripts/create_test_mail.sh --type MSGS --count 10 --days-old 45

# 3. Verify counts before truncation
bash scripts/mariadb -D agentj -e "SELECT COUNT(*) as 'Total MSGS' FROM msgs WHERE from_addr='sender@example.com';"

# Result: 15 total (5 young + 10 old)

# 4. Run truncate with 30 day cutoff
bash scripts/console agentj:truncate-message-since-days 30

# This should delete the 10 messages that are 45 days old

# 5. Verify only 5 young messages remain
bash scripts/mariadb -D agentj -e "SELECT COUNT(*) as 'Remaining MSGS' FROM msgs WHERE from_addr='sender@example.com';"

# Result: 5 (only the 5-day-old young messages remain)

# 6. Cleanup
bash scripts/mariadb -D agentj -e "DELETE FROM msgs WHERE from_addr='sender@example.com';"
```

The script allow to create out_msg and out_quarantine and creating the recepient for each.

I tested the truncate that keep younger message of each type 
Each time I verified that there is no orphaned rcpt or qurantine



## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works on both Firefox and Chrome
- [x] Tests are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
