### PR TITLE
289 translate the emails sent by agentj using the users locale

### DIFF
--- a/app/src/Service/LocaleService.php
+++ b/app/src/Service/LocaleService.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\User;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+/**
+ * @phpstan-type LocaleCode key-of<self::SUPPORTED_LOCALES>
+ */
+class LocaleService
+{
+    public const SUPPORTED_LOCALES = [
+        'en' => 'English',
+        'fr' => 'Français',
+    ];
+
+    /** @var LocaleCode */
+    private string $defaultLocale;
+
+    /**
+     * @return array<LocaleCode>
+     */
+    public static function getSupportedLocalesCodes(): array
+    {
+        return array_keys(self::SUPPORTED_LOCALES);
+    }
+
+    public function __construct(
+        #[Autowire(env: 'DEFAULT_LOCALE')]
+        string $defaultLocale,
+    ) {
+        if ($this->isAvailable($defaultLocale)) {
+            /** @var LocaleCode $defaultLocale */
+            $this->defaultLocale = $defaultLocale;
+        } else {
+            $this->defaultLocale = 'en';
+        }
+    }
+
+    /**
+     * @return LocaleCode
+     */
+    public function getDefaultLocale(): string
+    {
+        return $this->defaultLocale;
+    }
+
+    public function isAvailable(string $locale): bool
+    {
+        return isset(self::SUPPORTED_LOCALES[$locale]);
+    }
+
+    /**
+     * Get the locale for a user based on their preferences
+     * Priority: User's preferred lang > Domain's default lang > Default locale
+     *
+     * @return LocaleCode
+     */
+    public function getUserLocale(?User $user): string
+    {
+        if ($user === null) {
+            return $this->defaultLocale;
+        }
+
+        if ($user->getPreferedLang() !== null && $this->isAvailable($user->getPreferedLang())) {
+            /** @var LocaleCode $locale */
+            $locale = $user->getPreferedLang();
+            return $locale;
+        }
+
+        $domain = $user->getDomain();
+        if ($domain && $domain->getDefaultLang() !== null && $this->isAvailable($domain->getDefaultLang())) {
+            /** @var LocaleCode $locale */
+            $locale = $domain->getDefaultLang();
+            return $locale;
+        }
+
+        return $this->defaultLocale;
+    }
+}

--- a/app/templates/report/table_mail_msgs.html.twig
+++ b/app/templates/report/table_mail_msgs.html.twig
@@ -15,7 +15,7 @@
           <td width="100" style="min-width: 100px;">
             <div style="width: 100px;">
               <a href="{{ url('portal_message_authorized',{'token':token,'partitionTag':messageRecipient.partitionTag,'mailId':messageRecipient.getMailIdAsString(),'recipientId':messageRecipient.rid.id}) }}"
-                 title={{ 'Message.Actions.AutorizedSender'|trans() }} style="font-size:16px;
+                 title={{ 'Message.Actions.AutorizedSender'|trans(locale: locale) }} style="font-size:16px;
                  -moz-border-radius: 5px;
                  -webkit-border-radius: 5px;
                  border-radius: 5px;
@@ -26,7 +26,7 @@
                  color: #fff;
                  text-decoration: none;
                  ">
-                {{ 'Message.Actions.Autorized'|trans() }}
+                {{ 'Message.Actions.Autorized'|trans(locale: locale) }}
               </a>
             </div>
           </td>
@@ -34,7 +34,7 @@
           <td width="100" style="min-width: 100px;">
             <div style="width: 100px;">
               <a href="{{ url('portal_message_restore',{'token':token,'partitionTag':messageRecipient.partitionTag,'mailId':messageRecipient.getMailIdAsString(),'recipientId':messageRecipient.rid.id}) }}"
-                 title="{{ 'Message.Actions.RestoreMessage'|trans() }}" style="font-size:16px;
+                 title="{{ 'Message.Actions.RestoreMessage'|trans(locale: locale) }}" style="font-size:16px;
                  -moz-border-radius: 5px;
                  -webkit-border-radius: 5px;
                  border-radius: 5px;
@@ -44,7 +44,7 @@
                  color: #fff;
                  text-decoration: none;
                  ">
-                {{ 'Message.Actions.Restore'|trans() }}</a>
+                {{ 'Message.Actions.Restore'|trans(locale: locale) }}</a>
             </div>
           </td>
 


### PR DESCRIPTION
## Related issue(s)
https://github.com/Probesys/agentj/issues/289

To avoid duplication I created a LocalService that does the same logic as UserPreference -> DomainPreference -> Default


## How to test manually

For my tests, I mainly used the scripts -> mail_to_agentj.sh

By changing the "from" variable I can easily create mail that require an authentification to test SendAuthMailRequestCommand after that only need to change the prefered langage to see if it's taken into account.

For the ReportSendMailCommand, even more simpler just change the prefered langage, send any mail with the script to trigger a new report and you can see if the translation is done or not

Since the last place where there was the logic of if elsif else for the local was the CreateAlerteMessage, I took the liberty to update it too, but i had a hard time testing it the command for the alert since the CreateAlertFor Command wasn't working so I did some edit on local on my part to the createalertforCommand to test it and it worked



## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works on both Firefox and Chrome
- [x] Tests are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
