### PR TITLE
Allow to select LDAP "encryption" and "version"

### DIFF
--- a/app/migrations/Version20251215091724.php
+++ b/app/migrations/Version20251215091724.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+// phpcs:disable Generic.Files.LineLength
+final class Version20251215091724 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add the ldap_encryption and ldap_version to the connector table.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE connector ADD ldap_encryption VARCHAR(255) DEFAULT \'none\', ADD ldap_version INT DEFAULT 3');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE connector DROP ldap_encryption, DROP ldap_version');
+    }
+}

--- a/app/src/Entity/LdapConnector.php
+++ b/app/src/Entity/LdapConnector.php
@@ -52,6 +52,12 @@ class LdapConnector extends Connector
     #[ORM\Column(length: 255, nullable: true)]
     private ?string $ldapSharedWithField = null;
 
+    #[ORM\Column(type: 'string', length: 255, options: ['default' => 'none'])]
+    private string $ldapEncryption = 'none';
+
+    #[ORM\Column(type: 'integer', options: ['default' => 3])]
+    private int $ldapVersion = 3;
+
 
     public function getLdapHost(): ?string
     {
@@ -219,6 +225,30 @@ class LdapConnector extends Connector
     public function setLdapSharedWithField(?string $ldapSharedWithField): static
     {
         $this->ldapSharedWithField = $ldapSharedWithField;
+
+        return $this;
+    }
+
+    public function getLdapEncryption(): string
+    {
+        return $this->ldapEncryption;
+    }
+
+    public function setLdapEncryption(string $ldapEncryption): static
+    {
+        $this->ldapEncryption = $ldapEncryption;
+
+        return $this;
+    }
+
+    public function getLdapVersion(): int
+    {
+        return $this->ldapVersion;
+    }
+
+    public function setLdapVersion(int $ldapVersion): static
+    {
+        $this->ldapVersion = $ldapVersion;
 
         return $this;
     }

--- a/app/src/Form/LdapConnectorType.php
+++ b/app/src/Form/LdapConnectorType.php
@@ -6,6 +6,8 @@ use App\Entity\LdapConnector;
 use App\Entity\Groups;
 use App\Repository\GroupsRepository;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -27,6 +29,19 @@ class LdapConnectorType extends ConnectorType
                 'required' => true,
                 'label' => 'Entities.LdapConnector.fields.ldapPort',
                 'attr' => ['pattern' => '[0-9]+']
+            ])
+            ->add('ldapEncryption', ChoiceType::class, [
+                'required' => true,
+                'label' => 'Entities.LdapConnector.fields.ldapEncryption',
+                'choices' => [
+                    'None' => 'none',
+                    'SSL' => 'ssl',
+                    'TLS' => 'tls',
+                ],
+            ])
+            ->add('ldapVersion', IntegerType::class, [
+                'required' => true,
+                'label' => 'Entities.LdapConnector.fields.ldapVersion',
             ])
             ->add('LdapBaseDN', null, [
                 'required' => true,

--- a/app/src/Service/LdapService.php
+++ b/app/src/Service/LdapService.php
@@ -21,6 +21,8 @@ class LdapService
         $ldap = Ldap::create('ext_ldap', [
                     'host' => $connector->getLdapHost(),
                     'port' => $connector->getLdapPort(),
+                    'encryption' => $connector->getLdapEncryption(),
+                    'version' => $connector->getLdapVersion(),
         ]);
 
         if ($connector->isAllowAnonymousBind()) {
@@ -67,6 +69,8 @@ class LdapService
         $ldap = Ldap::create('ext_ldap', [
             'host' => $originConnector->getLdapHost(),
             'port' => $originConnector->getLdapPort(),
+            'encryption' => $originConnector->getLdapEncryption(),
+            'version' => $originConnector->getLdapVersion(),
         ]);
 
         try {

--- a/app/templates/connector/_form_ldap.html.twig
+++ b/app/templates/connector/_form_ldap.html.twig
@@ -34,6 +34,26 @@
         </div>
     </div>
 
+    <div class="row">
+        <div class="col-md-6">
+            <div class="form-group">
+                <label for="ldap_connector_ldapEncryption">
+                    {{ 'Entities.LdapConnector.fields.ldapEncryption'|trans }}
+                </label>
+                {{ form_widget(form.ldapEncryption) }}
+            </div>
+        </div>
+
+        <div class="col-md-2">
+            <div class="form-group">
+                <label for="ldap_connector_ldapVersion">
+                    {{ 'Entities.LdapConnector.fields.ldapVersion'|trans }}
+                </label>
+                {{ form_widget(form.ldapVersion) }}
+            </div>
+        </div>
+    </div>
+
     <fieldset>
         <legend>
             {{ 'Entities.LdapConnector.fields.connectionInformation' | trans }}

--- a/app/translations/messages.en.yml
+++ b/app/translations/messages.en.yml
@@ -657,6 +657,8 @@ Entities:
       connectionInformation: "Connection information"
       ldapHost: "Host"
       ldapPort: "Port (default 389)"
+      ldapEncryption: "Encryption"
+      ldapVersion: "LDAP version"
       allowAnonymousBind: "Anonymous connection"
       LdapBaseDN: "Base DN"
       ldapBindDn: "Bind DN"

--- a/app/translations/messages.fr.yml
+++ b/app/translations/messages.fr.yml
@@ -657,6 +657,8 @@ Entities:
       connectionInformation: "Informations de connexion"
       ldapHost: "Hôte"
       ldapPort: "Port (défaut 389)"
+      ldapEncryption: "Chiffrement"
+      ldapVersion: "Version LDAP"
       allowAnonymousBind: "Connexion anonyme"
       LdapBaseDN: "Base DN"
       ldapBindDn: "Bind DN"


### PR DESCRIPTION
## Related issue(s)
https://github.com/Probesys/agentj/issues/333

## How to test manually
Run the migration to add the new columns
Create a test domain, and add to it an ldap server you should see in the form two new fields
After creating it check if they're correctly set in the database

## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works on both Firefox and Chrome
- [x] Tests are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
