### PR TITLE
chore: Associate LDAP aliases to their connector

### DIFF
--- a/app/src/Command/LDAPImportCommand.php
+++ b/app/src/Command/LDAPImportCommand.php
@@ -248,6 +248,7 @@ class LDAPImportCommand extends Command
         $alias = $this->em->getRepository(User::class)->findOneBy(['email' => $aliasEmail]);
         if (!$alias) {
             $alias = new User();
+            $alias->setOriginConnector($this->connector);
             $this->nbAliasCreated++;
         }
 


### PR DESCRIPTION
## Related issue(s)
<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

N/A

## How to test manually
<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

- Create a LDAP connector as explained in the doc
- Import the users and the aliases
- Check that the imported aliases are associated to the connector: `./scripts/mariadb agentj -e 'select origin_connector_id from users where original_user_id is not null;'`

## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works on both Firefox and Chrome
- [x] Tests are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
