### PR TITLE
chore: Display custom error page only in production

### DIFF
--- a/app/config/packages/framework.yaml
+++ b/app/config/packages/framework.yaml
@@ -23,10 +23,12 @@ framework:
     php_errors:
         log: true
 
-    error_controller: 'App\Controller\CustomExceptionController::showAction'
-
 when@test:
     framework:
         test: true
         session:
             storage_id: session.storage.mock_file
+
+when@prod:
+    framework:
+        error_controller: 'App\Controller\CustomExceptionController::showAction'


### PR DESCRIPTION
## Related issue(s)
<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

N/A

## How to test manually
<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Edit a controller to introduce an error (e.g. stop passing a variable to a template)
2. Go to the impacted page
3. Verify you get a Symfony error page complaining about the issue (instead of a generic error page)

## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works on both Firefox and Chrome
- [x] Tests are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
