### PR TITLE
feat: Allow to customise the human authentication stylesheet

### DIFF
--- a/app/migrations/Version20251121133821.php
+++ b/app/migrations/Version20251121133821.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+// phpcs:disable Generic.Files.LineLength
+final class Version20251121133821 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add the human_authentication_stylesheet column to domain table.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE domain ADD human_authentication_stylesheet LONGTEXT DEFAULT \'\' NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE domain DROP human_authentication_stylesheet');
+    }
+}

--- a/app/src/Controller/HumanAuthenticationsController.php
+++ b/app/src/Controller/HumanAuthenticationsController.php
@@ -2,6 +2,7 @@
 
 namespace App\Controller;
 
+use App\Entity\Domain;
 use App\Entity\Wblist;
 use App\Form\CaptchaFormType;
 use App\Repository\MsgsRepository;
@@ -97,5 +98,20 @@ class HumanAuthenticationsController extends AbstractController
             'content' => $content,
             'domain' => $domain,
         ]);
+    }
+
+    #[Route(
+        path: '/portal/domains/{id}/human-authentication-stylesheet.css',
+        name: 'human_authentication_stylesheet',
+        methods: ['GET'],
+    )]
+    public function showStylesheet(Domain $domain): Response
+    {
+        $stylesheet = $domain->getHumanAuthenticationStylesheet();
+
+        $response = new Response($stylesheet);
+        $response->headers->set('Content-Type', 'text/css');
+
+        return $response;
     }
 }

--- a/app/src/Entity/Domain.php
+++ b/app/src/Entity/Domain.php
@@ -62,6 +62,9 @@ class Domain
     #[ORM\Column(type: Types::TEXT, nullable: true)]
     private ?string $confirmCaptchaMessage;
 
+    #[ORM\Column(type: Types::TEXT, options: ['default' => ''])]
+    private string $humanAuthenticationStylesheet = '';
+
     /**
      * @var Collection<int, Groups>
      */
@@ -273,6 +276,18 @@ class Domain
     public function setConfirmCaptchaMessage(?string $confirmCaptchaMessage): self
     {
         $this->confirmCaptchaMessage = $confirmCaptchaMessage;
+
+        return $this;
+    }
+
+    public function getHumanAuthenticationStylesheet(): string
+    {
+        return $this->humanAuthenticationStylesheet;
+    }
+
+    public function setHumanAuthenticationStylesheet(string $humanAuthenticationStylesheet): static
+    {
+        $this->humanAuthenticationStylesheet = $humanAuthenticationStylesheet;
 
         return $this;
     }

--- a/app/src/Form/DomainCustomisationHumanAuthenticationType.php
+++ b/app/src/Form/DomainCustomisationHumanAuthenticationType.php
@@ -30,6 +30,11 @@ class DomainCustomisationHumanAuthenticationType extends AbstractType
                 'data-controller' => 'ckeditor',
             ],
         ]);
+        $builder->add('humanAuthenticationStylesheet', TextareaType::class, [
+            'required' => false,
+            'empty_data' => '',
+            'label' => 'Entities.Domain.fields.humanAuthenticationStylesheet',
+        ]);
     }
 
     public function configureOptions(OptionsResolver $resolver): void

--- a/app/templates/domain/customisation/human_authentication.html.twig
+++ b/app/templates/domain/customisation/human_authentication.html.twig
@@ -20,6 +20,7 @@
             <div class="col-9">
                 {{ form_row(form.message) }}
                 {{ form_row(form.confirmCaptchaMessage) }}
+                {{ form_row(form.humanAuthenticationStylesheet) }}
             </div>
         </div>
 

--- a/app/templates/human_authentications/show.html.twig
+++ b/app/templates/human_authentications/show.html.twig
@@ -1,5 +1,10 @@
-
 {% extends 'base_security.html.twig' %}
+
+{% block head_css %}
+    {{ parent() }}
+
+    <link rel="stylesheet" href="{{ path('human_authentication_stylesheet', { id: domain.id }) }}">
+{% endblock %}
 
 {% block body %}
   <div class="h-100 ">

--- a/app/translations/messages.en.yml
+++ b/app/translations/messages.en.yml
@@ -463,6 +463,7 @@ Entities:
       mailmessage: "Text of the email validating the email address with the human authentication link"
       message: "Presentation text on the human authentication page"
       confirmCaptchaMessage: "Human authentication validation message"
+      humanAuthenticationStylesheet: "Custom stylesheet on the human authentication page"
       messageAlert: "Message of the report"
       domain: "Domain name"
       srvSmtp: "SMTP server"

--- a/app/translations/messages.fr.yml
+++ b/app/translations/messages.fr.yml
@@ -463,6 +463,7 @@ Entities:
       mailmessage: Texte du mail de validation de l'email avec le lien d'authentification humaine
       message: Texte de présentation sur la page d'authentification humaine
       confirmCaptchaMessage: Message de validation de l'authentification humaine
+      humanAuthenticationStylesheet: Feuille de style personnalisée de la page d'authentification humaine
       messageAlert: Message du rapport
       domain: Nom de domaine
       srvSmtp: Serveur SMTP


### PR DESCRIPTION
## Related issue(s)
<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

#292 

## How to test manually
<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Add custom CSS for the domain blocnormal.fr (e.g. `body { background: green !important; }`)
2. Verify that `root@smtp.test` is not an authorized user
3. Send an email + the authentication mail:
    - `./scripts/mail_to_agentj.sh`
    - `./scripts/console agentj:send-auth-mail-token`
4. Click on the link in the mail and verify that the stylesheet is applied to the page

## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works on both Firefox and Chrome
- [x] Tests are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
