### PR TITLE
feat: Allow to customise the list of messages in the report

### DIFF
--- a/app/src/Controller/Domain/CustomisationController.php
+++ b/app/src/Controller/Domain/CustomisationController.php
@@ -127,6 +127,12 @@ class CustomisationController extends AbstractController
                 'NB_DELETED_MESSAGES' => new TranslatableMessage('Entities.Domain.labels.dynamicsVariables.NB_DELETED_MESSAGES'),
                 'NB_RESTORED_MESSAGES' => new TranslatableMessage('Entities.Domain.labels.dynamicsVariables.NB_RESTORED_MESSAGES'),
                 'LIST_MAIL_MSGS' => new TranslatableMessage('Entities.Domain.labels.dynamicsVariables.LIST_MAIL_MSGS'),
+                'FOREACH_MESSAGE' => new TranslatableMessage('Entities.Domain.labels.dynamicsVariables.FOREACH_MESSAGE'),
+                'ENDFOREACH_MESSAGE' => new TranslatableMessage('Entities.Domain.labels.dynamicsVariables.ENDFOREACH_MESSAGE'),
+                'MESSAGE_SENDER' => new TranslatableMessage('Entities.Domain.labels.dynamicsVariables.MESSAGE_SENDER'),
+                'MESSAGE_SUBJECT' => new TranslatableMessage('Entities.Domain.labels.dynamicsVariables.MESSAGE_SUBJECT'),
+                'URL_MESSAGE_AUTHORIZE_SENDER' => new TranslatableMessage('Entities.Domain.labels.dynamicsVariables.URL_MESSAGE_AUTHORIZE_SENDER'),
+                'URL_MESSAGE_RESTORE' => new TranslatableMessage('Entities.Domain.labels.dynamicsVariables.URL_MESSAGE_RESTORE'),
             ],
             // phpcs:enable Generic.Files.LineLength
         ]);

--- a/app/templates/report/table_mail_msgs.html.twig
+++ b/app/templates/report/table_mail_msgs.html.twig
@@ -1,20 +1,20 @@
-{% if untreatedMsgs is not empty %}
+{% if untreatedMessageRecipients is not empty %}
   <table style="width:100%;background-color: #fff;">
     <tbody>
-      {% for msg in untreatedMsgs %}
-        {% set token = message_release_token(msg.msgs, user) %}
+      {% for messageRecipient in untreatedMessageRecipients %}
+        {% set token = message_release_token(messageRecipient.msgs, user) %}
         <tr>
 
           <td>
             <div>
-              <strong>{{ msg.msgs.fromAddr }}</strong><br>
-              <p style="font-size: 10px">{{ msg.msgs.subject }}</p>
+              <strong>{{ messageRecipient.msgs.fromAddr }}</strong><br>
+              <p style="font-size: 10px">{{ messageRecipient.msgs.subject }}</p>
             </div>
           </td>
 
           <td width="100" style="min-width: 100px;">
             <div style="width: 100px;">
-              <a href="{{ url('portal_message_authorized',{'token':token,'partitionTag':msg.partitionTag,'mailId':msg.getMailIdAsString(),'recipientId':msg.rid.id}) }}"
+              <a href="{{ url('portal_message_authorized',{'token':token,'partitionTag':messageRecipient.partitionTag,'mailId':messageRecipient.getMailIdAsString(),'recipientId':messageRecipient.rid.id}) }}"
                  title={{ 'Message.Actions.AutorizedSender'|trans() }} style="font-size:16px;
                  -moz-border-radius: 5px;
                  -webkit-border-radius: 5px;
@@ -33,7 +33,7 @@
 
           <td width="100" style="min-width: 100px;">
             <div style="width: 100px;">
-              <a href="{{ url('portal_message_restore',{'token':token,'partitionTag':msg.partitionTag,'mailId':msg.getMailIdAsString(),'recipientId':msg.rid.id}) }}"
+              <a href="{{ url('portal_message_restore',{'token':token,'partitionTag':messageRecipient.partitionTag,'mailId':messageRecipient.getMailIdAsString(),'recipientId':messageRecipient.rid.id}) }}"
                  title="{{ 'Message.Actions.RestoreMessage'|trans() }}" style="font-size:16px;
                  -moz-border-radius: 5px;
                  -webkit-border-radius: 5px;

--- a/app/translations/messages.en.yml
+++ b/app/translations/messages.en.yml
@@ -525,6 +525,12 @@ Entities:
         NB_DELETED_MESSAGES: "Number of deleted messages"
         NB_RESTORED_MESSAGES: "Number of restored messages"
         LIST_MAIL_MSGS: "List of untreated messages"
+        FOREACH_MESSAGE: "Start of message loop"
+        ENDFOREACH_MESSAGE: "End of message loop"
+        MESSAGE_SENDER: "Name of the message's sender"
+        MESSAGE_SUBJECT: "Subject of the message"
+        URL_MESSAGE_AUTHORIZE_SENDER: "URL to authorize the message's sender"
+        URL_MESSAGE_RESTORE: "URL to recover the message"
     actions:
       add_connector: Add connector
       importUserAndAliases: "Import users and aliases"

--- a/app/translations/messages.fr.yml
+++ b/app/translations/messages.fr.yml
@@ -525,6 +525,12 @@ Entities:
         NB_DELETED_MESSAGES: Nombre de messages supprimés
         NB_RESTORED_MESSAGES: Nombre de messages restaurés
         LIST_MAIL_MSGS: Liste des messages non traités
+        FOREACH_MESSAGE: "Début de la boucle des messages"
+        ENDFOREACH_MESSAGE: "Fin de la boucle des messages"
+        MESSAGE_SENDER: "Nom de l'expéditeur du message"
+        MESSAGE_SUBJECT: "Sujet du message"
+        URL_MESSAGE_AUTHORIZE_SENDER: "URL autorisant l'expéditeur du message"
+        URL_MESSAGE_RESTORE: "URL récupérant le message"
     actions:
       add_connector: Ajouter un connecteur
       importUserAndAliases: "Importer les utilisateurs et les alias"


### PR DESCRIPTION
## Related issue(s)
<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

N/A

## How to test manually
<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Customise the report email template with:
```html
[FOREACH_MESSAGE]
    <div>
        <p>Expéditeur : <strong>[MESSAGE_SENDER]</strong></p>
        <p>Objet du mail : <strong>[MESSAGE_SUBJECT]</strong></p>

        <a href="[URL_MESSAGE_AUTHORIZE_SENDER]">Autoriser l'expéditeur</a>
        <a href="[URL_MESSAGE_RESTORE]">Récupérer l'e-mail</a>
    </div>
[ENDFOREACH_MESSAGE]
```
2. Envoyer un mail avec `./scripts/mail_to_agentj.sh`
3. Envoyer le rapport avec `./scripts/console agentj:report-send-mail`
4. Vérifier dans le rapport que le message apparaît bien est qu’il peut être autorisé

## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works on both Firefox and Chrome
- [x] Tests are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
