### PR TITLE
feat: Allow to customise the human authentication footer

### DIFF
--- a/app/migrations/Version20251205081318.php
+++ b/app/migrations/Version20251205081318.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+// phpcs:disable Generic.Files.LineLength
+final class Version20251205081318 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add the human_authentication_footer column to domain table.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE domain ADD human_authentication_footer LONGTEXT DEFAULT \'\' NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE domain DROP human_authentication_footer');
+    }
+}

--- a/app/src/Entity/Domain.php
+++ b/app/src/Entity/Domain.php
@@ -65,6 +65,9 @@ class Domain
     #[ORM\Column(type: Types::TEXT, options: ['default' => ''])]
     private string $humanAuthenticationStylesheet = '';
 
+    #[ORM\Column(type: Types::TEXT, options: ['default' => ''])]
+    private string $humanAuthenticationFooter = '';
+
     /**
      * @var Collection<int, Groups>
      */
@@ -288,6 +291,18 @@ class Domain
     public function setHumanAuthenticationStylesheet(string $humanAuthenticationStylesheet): static
     {
         $this->humanAuthenticationStylesheet = $humanAuthenticationStylesheet;
+
+        return $this;
+    }
+
+    public function getHumanAuthenticationFooter(): string
+    {
+        return $this->humanAuthenticationFooter;
+    }
+
+    public function setHumanAuthenticationFooter(string $humanAuthenticationFooter): static
+    {
+        $this->humanAuthenticationFooter = $humanAuthenticationFooter;
 
         return $this;
     }

--- a/app/src/Form/DomainCustomisationHumanAuthenticationType.php
+++ b/app/src/Form/DomainCustomisationHumanAuthenticationType.php
@@ -18,18 +18,30 @@ class DomainCustomisationHumanAuthenticationType extends AbstractType
                 'data-controller' => 'ckeditor',
             ],
         ]);
+
         $builder->add('message', TextareaType::class, [
             'label' => 'Entities.Domain.fields.message',
             'attr' => [
                 'data-controller' => 'ckeditor',
             ],
         ]);
+
         $builder->add('confirmCaptchaMessage', TextareaType::class, [
             'label' => 'Entities.Domain.fields.confirmCaptchaMessage',
             'attr' => [
                 'data-controller' => 'ckeditor',
             ],
         ]);
+
+        $builder->add('humanAuthenticationFooter', TextareaType::class, [
+            'required' => false,
+            'empty_data' => '',
+            'label' => 'Entities.Domain.fields.humanAuthenticationFooter',
+            'attr' => [
+                'data-controller' => 'ckeditor',
+            ],
+        ]);
+
         $builder->add('humanAuthenticationStylesheet', TextareaType::class, [
             'required' => false,
             'empty_data' => '',

--- a/app/templates/base.new.html.twig
+++ b/app/templates/base.new.html.twig
@@ -20,8 +20,8 @@
             {% block body %}{% endblock %}
         </main>
 
-        {% block footer %}
-            <footer class="layout__footer">
+        <footer class="layout__footer">
+            {% block footer %}
                 <div class="wrapper wrapper--larger wrapper--center cols cols--gap-large">
                     <p class="col--extend">
                         © Copyright {{ "now"|date('Y') }}
@@ -41,7 +41,7 @@
                         </a>
                     </p>
                 </div>
-            </footer>
-        {% endblock %}
+            {% endblock %}
+        </footer>
     </body>
 </html>

--- a/app/templates/domain/customisation/human_authentication.html.twig
+++ b/app/templates/domain/customisation/human_authentication.html.twig
@@ -20,6 +20,7 @@
             <div class="col-9">
                 {{ form_row(form.message) }}
                 {{ form_row(form.confirmCaptchaMessage) }}
+                {{ form_row(form.humanAuthenticationFooter) }}
                 {{ form_row(form.humanAuthenticationStylesheet) }}
             </div>
         </div>

--- a/app/templates/human_authentications/show.html.twig
+++ b/app/templates/human_authentications/show.html.twig
@@ -51,3 +51,11 @@
         </div>
     </div>
 {% endblock %}
+
+{% block footer %}
+    {% if domain.humanAuthenticationFooter %}
+        {{ domain.humanAuthenticationFooter | raw }}
+    {% else %}
+        {{ parent() }}
+    {% endif %}
+{% endblock %}

--- a/app/translations/messages.en.yml
+++ b/app/translations/messages.en.yml
@@ -475,6 +475,7 @@ Entities:
       mailmessage: "Text of the email validating the email address with the human authentication link"
       message: "Presentation text on the human authentication page"
       confirmCaptchaMessage: "Human authentication validation message"
+      humanAuthenticationFooter: "Footer of the human authentication page"
       humanAuthenticationStylesheet: "Custom stylesheet on the human authentication page"
       messageAlert: "Message of the report"
       domain: "Domain name"

--- a/app/translations/messages.fr.yml
+++ b/app/translations/messages.fr.yml
@@ -475,6 +475,7 @@ Entities:
       mailmessage: Texte du mail de validation de l'email avec le lien d'authentification humaine
       message: Texte de présentation sur la page d'authentification humaine
       confirmCaptchaMessage: Message de validation de l'authentification humaine
+      humanAuthenticationFooter: Pied de page de la page d'authentification humaine
       humanAuthenticationStylesheet: Feuille de style personnalisée de la page d'authentification humaine
       messageAlert: Message du rapport
       domain: Nom de domaine


### PR DESCRIPTION
## Related issue(s)
<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

Closes #292

## How to test manually
<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Customize the footer of the blocnormal.fr domain
```html
<p class="text--center">Custom footer</p>
```
2. Send an email (`./scripts/mail_to_agentj.sh`) and the human authentication request (`./scripts/console agentj:send-auth-mail-token`)
3. Open the authentication page and check that the footer changed

## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works on both Firefox and Chrome
- [x] Tests are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
