### PR TITLE
Don't disable milters for outsmtp Postfix

### DIFF
--- a/smtp/out/master.cf
+++ b/smtp/out/master.cf
@@ -69,7 +69,7 @@ amavisfeed unix    -       -       n        -      $AMAVIS_PROCESSES     lmtp
     -o smtpd_hard_error_limit=1000
     -o smtpd_client_connection_count_limit=0
     -o smtpd_client_connection_rate_limit=0
-    -o receive_override_options=no_header_body_checks,no_unknown_recipient_checks,no_milters
+    -o receive_override_options=no_header_body_checks,no_unknown_recipient_checks
     -o local_header_rewrite_clients=
 
 postlog   unix-dgram n  -       n       -       1       postlogd


### PR DESCRIPTION
Needed to sign outgoing emails with DKIM

## Related issue(s)
<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

https://github.com/Probesys/agentj/issues/351

## How to test manually
<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works on both Firefox and Chrome
- [x] Tests are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
