### PR TITLE
fix: Fix saving status and captcha time on human authorization

### DIFF
--- a/app/src/Controller/DefaultController.php
+++ b/app/src/Controller/DefaultController.php
@@ -260,7 +260,6 @@ class DefaultController extends AbstractController
         Service\MessageService $messageService,
         Service\CryptEncryptService $cryptEncrypt,
     ): Response {
-        $em = $this->em;
         $confirm = "";
 
         list($message, $domain, $messageRecipients) = $this->decryptMessageToken($cryptEncrypt, $token);
@@ -311,10 +310,8 @@ class DefaultController extends AbstractController
             // Test if the sender is the same than the posted email field and if the mail has not been yet treated
             if (!$message->getStatus() && $form->has('email') && $form->get('email')->getData() == $senderEmail) {
                 if ($form->has('emailEmpty') && empty($form->get('emailEmpty')->getData())) { // Test HoneyPot
-                    $messageService->authorize($message, $messageRecipients, Wblist::WBLIST_TYPE_AUTHENTICATION);
                     $message->setValidateCaptcha(time());
-                    $em->persist($message);
-                    $em->flush();
+                    $messageService->authorize($message, $messageRecipients, Wblist::WBLIST_TYPE_AUTHENTICATION);
                 } else {
                     $this->addFlash('error', $this->translator->trans('Message.Flash.checkMailUnsuccessful'));
                 }

--- a/app/src/Entity/BaseMessage.php
+++ b/app/src/Entity/BaseMessage.php
@@ -342,9 +342,9 @@ class BaseMessage
         return $this;
     }
 
-    public function getMailId(): mixed
+    public function getMailId(): string
     {
-        return $this->mailId;
+        return $this->getMailIdAsString();
     }
 
     public function getMailIdAsString(): string


### PR DESCRIPTION
## Related issue(s)

The `message.mailId` value was read a first time in `MsgrcptRepository::findByMessage`, moving the resource pointer. Then, when calling `$em->flush()`, Doctrine was getting `null` when reading the `mailId` resource, preventing the database save.

Now, calling `message.getMailId()` always returns a string and resets the resource pointer. However, this doesn't fix saving the captcha validation time as Doctrine directly read the resource value and doesn't reset the pointer. So I moved the time setting before calling `messageService->authorize()` which is in charge to save the value in the database. Thus, we call `$em->flush()` only once for the message.

## How to test manually
<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Send an email with `./scripts/mail_to_agentj.sh`
2. Send the human authentication email with `./scripts/console agentj:send-auth-mail-token`
3. Click on the link in the email and validate the email
4. Check in the database that `status_id` and `validate_captcha` are set (`select status_id, validate_captcha from msgs where mail_id = 'MAIL_ID';`)

## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [ ] Code is manually tested
- [ ] Interface works on both mobiles and big screens
- [ ] Interface works on both Firefox and Chrome
- [ ] Tests are up to date
- [ ] Documentation is up to date
- [ ] Pull request has been reviewed and approved
