### PR TITLE
fix: Fix setting the locale

### DIFF
--- a/app/src/EventSubscriber/LocaleSubscriber.php
+++ b/app/src/EventSubscriber/LocaleSubscriber.php
@@ -2,39 +2,35 @@
 
 namespace App\EventSubscriber;
 
+use App\Service\LocaleService;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class LocaleSubscriber implements EventSubscriberInterface
 {
-    private string $defaultLocale;
-
-    public function __construct(string $defaultLocale = 'fr')
-    {
-        $this->defaultLocale = $defaultLocale;
+    public function __construct(
+        private LocaleService $localeService,
+    ) {
     }
 
     public function onKernelRequest(RequestEvent $event): void
     {
         $request = $event->getRequest();
-        if (!$request->hasPreviousSession()) {
-            return;
+
+        $supportedLocalesCodes = $this->localeService->getSupportedLocalesCodes();
+        $locale = $request->getPreferredLanguage($supportedLocalesCodes);
+
+        if ($request->hasPreviousSession()) {
+            $locale = $request->getSession()->get('_locale', $locale);
         }
 
-        // try to see if the locale has been set as a _locale routing parameter
-        if ($locale = $request->attributes->get('_locale')) {
-            $request->getSession()->set('_locale', $locale);
-        } else {
-            // if no explicit locale has been set on this request, use one from the session
-            $request->setLocale($request->getSession()->get('_locale', $this->defaultLocale));
-        }
+        $request->setLocale($locale);
     }
 
     public static function getSubscribedEvents(): array
     {
         return [
-            // must be registered before (i.e. with a higher priority than) the default Locale listener
             KernelEvents::REQUEST => [['onKernelRequest', 20]],
         ];
     }

--- a/app/src/EventSubscriber/UserLocaleSubscriber.php
+++ b/app/src/EventSubscriber/UserLocaleSubscriber.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\EventSubscriber;
+
+use App\Service\LocaleService;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
+use Symfony\Component\Security\Http\SecurityEvents;
+
+class UserLocaleSubscriber implements EventSubscriberInterface
+{
+    public function __construct(
+        private RequestStack $requestStack,
+        private LocaleService $localeService,
+    ) {
+    }
+
+    public function onInteractiveLogin(InteractiveLoginEvent $event): void
+    {
+        /** @var ?\App\Entity\User $user */
+        $user = $event->getAuthenticationToken()->getUser();
+
+        $request = $this->requestStack->getCurrentRequest();
+        $session = $this->requestStack->getSession();
+        $userLocale = $this->localeService->getUserLocale($user);
+
+        $session->set('_locale', $userLocale);
+        $request->setLocale($userLocale);
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            SecurityEvents::INTERACTIVE_LOGIN => 'onInteractiveLogin',
+        ];
+    }
+}

--- a/app/src/Security/LoginFormAuthenticator.php
+++ b/app/src/Security/LoginFormAuthenticator.php
@@ -164,18 +164,6 @@ class LoginFormAuthenticator extends AbstractLoginFormAuthenticator
 
     public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response
     {
-        /** @var User $user */
-        $user = $token->getUser();
-
-        if ($user->getDomain() && $user->getDomain()->getDefaultLang()) {
-            $request->getSession()->set('_locale', $user->getDomain()->getDefaultLang());
-        }
-
-
-        if ($user->getPreferedLang()) {
-            $request->getSession()->set('_locale', $user->getPreferedLang());
-        }
-
         if ($targetPath = $this->getTargetPath($request->getSession(), $firewallName)) {
             return new RedirectResponse($targetPath);
         }

--- a/app/templates/dashboard/stats-by-status.html.twig
+++ b/app/templates/dashboard/stats-by-status.html.twig
@@ -79,7 +79,7 @@
         if (filteredData.datasets[0].data.length === 0) { // Display a message if there is no data
             document.getElementById('messagesChart').style.display = 'none';
             var noDataMessage = document.createElement('p');
-            noDataMessage.textContent = 'Aucun message bloqué';
+            noDataMessage.textContent = '{{ 'Entities.Message.noBlockedMessages' | trans }}';
             noDataMessage.style.textAlign = 'center';
             noDataMessage.style.marginTop = '20px';
             document.getElementById('messagesChart').parentNode.appendChild(noDataMessage);

--- a/app/translations/messages.en.yml
+++ b/app/translations/messages.en.yml
@@ -622,6 +622,7 @@ Entities:
     spamLevel: Note
     dateAuthRequestAt: "Authentication request sent the"
     isMailingList: "Mailing list? "
+    noBlockedMessages: 'No blocked messages'
     labels:
       infos: "Information about the blockage"
       preview: "Preview of the message"

--- a/app/translations/messages.fr.yml
+++ b/app/translations/messages.fr.yml
@@ -622,6 +622,7 @@ Entities:
     spamLevel: Note
     dateAuthRequestAt: "Demande d'authentification envoyée le"
     isMailingList: "Mailing liste ? "
+    noBlockedMessages: 'Aucun message bloqué'
     labels:
       infos: "Informations sur les refus"
       preview: "Aperçu du message"


### PR DESCRIPTION
## Related issue(s)
<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

Two problems happened. First, the `Accept-Language` header was ignored when the user wasn't logged-in. It means that the French locale was always used. The refactor of the LocaleSubscriber fixes this.

The second problem was that once the session expired, but that the user was logged in again through the "remember me" cookie, the locale wasn't set anymore. This is why I introduce a UserLocaleSubscriber which is triggered on "interactive login", meaning it is called both on normal login, and on "remember me" login.

## How to test manually
<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. In the preference of your browser, put the English (en) as your preferred language
2. On login, check that the page is translated in English
3. Do the same with French (fr)
4. Once logged-in (with remember me checked), choose the English as default language
5. Remove the `PHPSESSID` cookie
6. Refresh the page and check that it's still translated in English

## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works on both Firefox and Chrome
- [x] Tests are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
