### PR TITLE
fix: Fix autorelease with a high number of untreated messages

### DIFF
--- a/app/src/Repository/UserRepository.php
+++ b/app/src/Repository/UserRepository.php
@@ -66,6 +66,16 @@ class UserRepository extends BaseRepository
     }
 
     /**
+     * @return User[]
+     */
+    public function findAllWithoutHumanAuthentication(): array
+    {
+        return $this->findBy([
+            'bypassHumanAuth' => true,
+        ]);
+    }
+
+    /**
      * Return all users from active domains
      *
      * @return array<int, array<string, int>>


### PR DESCRIPTION
## Related issue(s)
<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

An issue happened when there was a high number of untreated messages associated to users without the "bypass human authentication" option. Indeed, the `getSearchQuery()` could return 1000 messages concerning these users, while the 1001th message (not returned) could have concerned a user with the "bypass" option enabled.

Now, we iterate on the users with the option enabled and we get their untreated messages so we are sure to always load messages that need to be loaded.

## How to test manually
<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Load a large database with many untreated messages and few users
2. Deactivate human authentication for one of the user
3. Run `./scripts/console agentj:auto-release-message` and verify that messages are released for this user only

## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works on both Firefox and Chrome
- [x] Tests are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
