### PR TITLE
fix: Fix M365 import bugs concerning aliases

### DIFF
--- a/app/migrations/Version20260115151631.php
+++ b/app/migrations/Version20260115151631.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260115151631 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Fix M365 users marked as aliases of themselves.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('UPDATE users SET original_user_id = null WHERE original_user_id = id');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // Do nothing on purpose
+    }
+}

--- a/app/src/Command/Office365ImportCommand.php
+++ b/app/src/Command/Office365ImportCommand.php
@@ -179,6 +179,12 @@ class Office365ImportCommand extends Command
         foreach ($proxyAdresses as $proxyAdresse) {
             if (str_starts_with(strtolower($proxyAdresse), 'smtp:')) {
                 $aliasEmail = substr($proxyAdresse, strlen('smtp:'));
+
+                // Don't mark the initial user as an alias of himself
+                if ($aliasEmail === $user->getEmail()) {
+                    continue;
+                }
+
                 $domainAlias = explode('@', $aliasEmail)[1];
                 if ($domainAlias == $this->connector->getDomain()->getDomain()) {
                     $alias = $this->em->getRepository(User::class)->findOneBy(['email' => $aliasEmail]);

--- a/app/src/Command/Office365ImportCommand.php
+++ b/app/src/Command/Office365ImportCommand.php
@@ -177,8 +177,8 @@ class Office365ImportCommand extends Command
     {
         $aliases = [];
         foreach ($proxyAdresses as $proxyAdresse) {
-            if (strpos($proxyAdresse, "smtp") !== false) {
-                $aliasEmail = explode('smtp:', $proxyAdresse)[1];
+            if (str_starts_with(strtolower($proxyAdresse), 'smtp:')) {
+                $aliasEmail = substr($proxyAdresse, strlen('smtp:'));
                 $domainAlias = explode('@', $aliasEmail)[1];
                 if ($domainAlias == $this->connector->getDomain()->getDomain()) {
                     $alias = $this->em->getRepository(User::class)->findOneBy(['email' => $aliasEmail]);


### PR DESCRIPTION
## Related issue(s)
<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

Two main issues occurred:

- we were checking that proxy addresses contained "smtp" string anywhere in the string, before exploding the address on "smtp:". So addresses containing "smtp" in it but not starting with "smtp:" would break the import script
- if a proxy address was identical to the main address, the user would have been marked as an alias of himself

## How to test manually
<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

I wasn't able to configure Entra to replicate the issue :shrug: At least configure M365 in .env and a corresponding connector, run the import and try to login.

## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [ ] Code is manually tested
- [ ] Interface works on both mobiles and big screens
- [ ] Interface works on both Firefox and Chrome
- [ ] Tests are up to date
- [ ] Documentation is up to date
- [ ] Pull request has been reviewed and approved
