### PR TITLE
fix: Fix redirecting to the "Referer" URL

### DIFF
--- a/app/assets/controllers/button_pending_release_message_controller.js
+++ b/app/assets/controllers/button_pending_release_message_controller.js
@@ -24,6 +24,10 @@ export default class extends Controller {
             const url = this.urlValue;
             const response = await fetch(url, {
                 method: 'GET',
+                headers: {
+                    'Accept': 'application/json',
+                    'X-Requested-With': 'XMLHttpRequest',
+                },
             });
 
             if (!response.ok) {

--- a/app/assets/controllers/form-group_controller.js
+++ b/app/assets/controllers/form-group_controller.js
@@ -30,6 +30,7 @@ btnSubmitTarget.disabled = true
         method: 'POST',
         headers: {
           'Accept': 'application/json',
+          'X-Requested-With': 'XMLHttpRequest',
         },
         body: formData
       })

--- a/app/assets/controllers/form-ldap-connector_controller.js
+++ b/app/assets/controllers/form-ldap-connector_controller.js
@@ -29,6 +29,7 @@ export default class extends Controller {
         method: 'POST',
         headers: {
           'Accept': 'application/json',
+          'X-Requested-With': 'XMLHttpRequest',
         },
         body: formData
       })
@@ -74,6 +75,7 @@ export default class extends Controller {
         method: 'POST',
         headers: {
           'Accept': 'application/json',
+          'X-Requested-With': 'XMLHttpRequest',
         },
         body: formData
       })
@@ -100,6 +102,7 @@ export default class extends Controller {
         method: 'POST',
         headers: {
           'Accept': 'application/json',
+          'X-Requested-With': 'XMLHttpRequest',
         },
         body: formData
       })
@@ -113,8 +116,8 @@ export default class extends Controller {
     }
 
   }
-  
-  
+
+
   showHideGroupInfoEventClick(event) {
     this.showHideGroupInfo(event.target.checked);
   }
@@ -140,7 +143,7 @@ export default class extends Controller {
   showHideBindInfoEventClick(event) {
 
     this.showHideBindInfo(event.target.checked);
-  }  
+  }
 
   showHideBindInfo(checked) {
     const divBindingInfo = this.element.querySelector('#info-binding-ldap');
@@ -158,5 +161,5 @@ export default class extends Controller {
       });
     }
     this.checkConnection();
-  }    
+  }
 }

--- a/app/assets/controllers/message-counter_controller.js
+++ b/app/assets/controllers/message-counter_controller.js
@@ -25,7 +25,13 @@ export default class extends Controller {
             this[`${name}Target`].textContent = '...';
         });
 
-        fetch(this.urlValue)
+        fetch(this.urlValue, {
+            method: 'GET',
+            headers: {
+                'Accept': 'application/json',
+                'X-Requested-With': 'XMLHttpRequest',
+            },
+        })
             .then(response => {
                 if (!response.ok) {
                     throw new Error(`HTTP ${response.status}`);

--- a/app/src/Controller/ImportController.php
+++ b/app/src/Controller/ImportController.php
@@ -10,6 +10,7 @@ use App\Entity\User;
 use App\Entity\Wblist;
 use App\Form\ImportType;
 use App\Service\GroupService;
+use App\Service\Referrer;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Filesystem\Filesystem;
@@ -26,15 +27,12 @@ class ImportController extends AbstractController
     use ControllerCommonTrait;
     use ControllerWBListTrait;
 
-    private TranslatorInterface $translator;
-    private EntityManagerInterface $em;
-    private GroupService $groupService;
-
-    public function __construct(TranslatorInterface $translator, EntityManagerInterface $em, GroupService $groupService)
-    {
-        $this->translator = $translator;
-        $this->em = $em;
-        $this->groupService = $groupService;
+    public function __construct(
+        private TranslatorInterface $translator,
+        private EntityManagerInterface $em,
+        private GroupService $groupService,
+        private Referrer $referrer,
+    ) {
     }
 
     #[Route(path: '/users', name: 'import_user_email', options: ['expose' => true])]
@@ -66,8 +64,8 @@ class ImportController extends AbstractController
             } else {
                 $this->addFlash('danger', 'Generics.flash.BadFormatcsv');
             }
-            $referer = $request->headers->get('referer');
-            return $this->redirect($referer);
+
+            return $this->redirect($this->referrer->get());
         }
 
         return $this->render('import/index.html.twig', [
@@ -270,8 +268,8 @@ class ImportController extends AbstractController
             } else {
                 $this->addFlash('danger', 'Generics.flash.BadFormatcsv');
             }
-            $referer = $request->headers->get('referer');
-            return $this->redirect($referer);
+
+            return $this->redirect($this->referrer->get());
         }
 
         return $this->render('import/index_alias.html.twig', [

--- a/app/src/Controller/MessageController.php
+++ b/app/src/Controller/MessageController.php
@@ -32,7 +32,8 @@ class MessageController extends AbstractController
     public function __construct(
         private TranslatorInterface $translator,
         private EntityManagerInterface $em,
-        private Service\MessageService $messageService
+        private Service\MessageService $messageService,
+        private Service\Referrer $referrer,
     ) {
     }
 
@@ -249,11 +250,7 @@ class MessageController extends AbstractController
             $logService->addLog('delete', $mailId);
         }
 
-        if (!empty($request->headers->get('referer'))) {
-            return new RedirectResponse($request->headers->get('referer'));
-        } else {
-            return $this->redirectToRoute("message");
-        }
+        return new RedirectResponse($this->referrer->get());
     }
 
     #[Route(path: '/batch/{action}', name: 'message_batch', methods: 'POST', options: ['expose' => true])]
@@ -290,8 +287,7 @@ class MessageController extends AbstractController
             }
         }
 
-        $referer = $request->headers->get('referer');
-        return $this->redirect($referer);
+        return new RedirectResponse($this->referrer->get());
     }
 
     #[Route(path: '/{partitionTag}/{mailId}/{rid}/authorized', name: 'message_authorized')]
@@ -321,11 +317,7 @@ class MessageController extends AbstractController
             $logService->addLog('authorized', $mailId);
         }
 
-        if (!empty($request->headers->get('referer'))) {
-            return new RedirectResponse($request->headers->get('referer'));
-        } else {
-            return $this->redirectToRoute("message");
-        }
+        return new RedirectResponse($this->referrer->get());
     }
 
     #[Route(path: '/{partitionTag}/{mailId}/{rid}/banned', name: 'message_banned')]
@@ -355,11 +347,7 @@ class MessageController extends AbstractController
             $logService->addLog('banned', $mailId);
         }
 
-        if (!empty($request->headers->get('referer'))) {
-            return new RedirectResponse($request->headers->get('referer'));
-        } else {
-            return $this->redirectToRoute("message");
-        }
+        return new RedirectResponse($this->referrer->get());
     }
 
     /**
@@ -391,11 +379,7 @@ class MessageController extends AbstractController
         $this->addFlash('success', $this->translator->trans('Message.Flash.messagePendingRelease'));
         $logService->addLog('restore', $mailId);
 
-        if (!empty($request->headers->get('referer'))) {
-            return new RedirectResponse($request->headers->get('referer'));
-        } else {
-            return $this->redirectToRoute("message");
-        }
+        return new RedirectResponse($this->referrer->get());
     }
 
     #[IsGranted('ROLE_ADMIN')]
@@ -412,8 +396,7 @@ class MessageController extends AbstractController
             $logService->addLog('authorize for domain ', $mailId);
         }
 
-        $referer = $request->headers->get('referer');
-        return new RedirectResponse($referer);
+        return new RedirectResponse($this->referrer->get());
     }
 
     #[IsGranted('ROLE_ADMIN')]
@@ -430,8 +413,7 @@ class MessageController extends AbstractController
             $logService->addLog('banned for domain ', $mailId);
         }
 
-        $referer = $request->headers->get('referer');
-        return new RedirectResponse($referer);
+        return new RedirectResponse($this->referrer->get());
     }
 
     /**

--- a/app/src/Controller/WblistController.php
+++ b/app/src/Controller/WblistController.php
@@ -10,6 +10,7 @@ use App\Form\ImportType;
 use App\Entity\Domain;
 use App\Repository\WblistRepository;
 use App\Service\LogService;
+use App\Service\Referrer;
 use Doctrine\ORM\EntityManagerInterface;
 use Knp\Component\Pager\PaginatorInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -24,6 +25,7 @@ class WblistController extends AbstractController
     public function __construct(
         private TranslatorInterface $translator,
         private EntityManagerInterface $em,
+        private Referrer $referrer,
     ) {
     }
 
@@ -106,11 +108,7 @@ class WblistController extends AbstractController
             $this->addFlash('error', 'Invalid csrf token');
         }
 
-        if (!empty($request->headers->get('referer'))) {
-            return new RedirectResponse($request->headers->get('referer'));
-        } else {
-            return $this->redirectToRoute("message");
-        }
+        return new RedirectResponse($this->referrer->get());
     }
 
     private function deleteWbList(
@@ -153,8 +151,7 @@ class WblistController extends AbstractController
             $this->em->getRepository(Wblist::class)->delete($mailInfo[0], $mailInfo[1], $mailInfo[2]);
         }
 
-        $referer = $request->headers->get('referer');
-        return $this->redirect($referer);
+        return new RedirectResponse($this->referrer->get());
     }
 
 
@@ -185,8 +182,7 @@ class WblistController extends AbstractController
             }
         }
 
-        $referer = $request->headers->get('referer');
-        return $this->redirect($referer);
+        return new RedirectResponse($this->referrer->get());
     }
 
     #[Route(path: '/wblist/admin/import', name: 'import_wblist', options: ['expose' => true])]
@@ -206,8 +202,8 @@ class WblistController extends AbstractController
             } else {
                 $this->addFlash('danger', 'Generics.flash.BadFormatcsv');
             }
-            $referer = $request->headers->get('referer');
-            return $this->redirect($referer);
+
+            return new RedirectResponse($this->referrer->get());
         }
         return $this->render('import/index_wblist.html.twig', [
                     'controller_name' => 'ImportController',

--- a/app/src/EventSubscriber/PseudoReferrerSubscriber.php
+++ b/app/src/EventSubscriber/PseudoReferrerSubscriber.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\EventSubscriber;
+
+use App\Service\Referrer;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\FinishRequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * This subscriber saves the current (GET) URI in session to be used later as
+ * referrer if the Referer header is missing.
+ *
+ * The URI is saved at the end of the request, so getting the pseudo referrer
+ * in a GET request doesn't return the current URI, but the previous one.
+ */
+class PseudoReferrerSubscriber implements EventSubscriberInterface
+{
+    public function __construct(
+        private Referrer $referrer,
+    ) {
+    }
+
+    public function savePseudoReferrer(FinishRequestEvent $event): void
+    {
+        if (!$event->isMainRequest()) {
+            // Ignore sub-requests such as embedded controllers or internal
+            // redirects.
+            return;
+        }
+
+        $this->referrer->savePseudoReferrer();
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::FINISH_REQUEST => 'savePseudoReferrer',
+        ];
+    }
+}

--- a/app/src/Service/Referrer.php
+++ b/app/src/Service/Referrer.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace App\Service;
+
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+class Referrer
+{
+    public function __construct(
+        private RequestStack $requestStack,
+        private UrlGeneratorInterface $urlGenerator,
+        #[Autowire(env: 'APP_URL')]
+        private string $appUrl,
+    ) {
+    }
+
+    /**
+     * Return the referrer URL of the current request.
+     *
+     * Use this method to get the referrer URL safely.
+     *
+     * It considers the Referer header in priority. If it's missing, it returns
+     * a "pseudo" referrer saved in the session (see the savePseudoReferrer()
+     * method).
+     *
+     * The referrer is always an internal URL or path. If the referrer found in
+     * the header/session targets an external domain, the method returns the
+     * path to the homepage.
+     */
+    public function get(): string
+    {
+        $request = $this->requestStack->getCurrentRequest();
+        $session = $request->getSession();
+
+        $lastGetUrl = $session->get('_referrer', '');
+        $referrer = $request->headers->get('Referer', $lastGetUrl);
+
+        if ($this->isSafeUrl($referrer)) {
+            return $referrer;
+        } else {
+            return $this->urlGenerator->generate('homepage');
+        }
+    }
+
+    /**
+     * Save the current URI in session to be used later as referrer if the
+     * Referer header is missing.
+     *
+     * The URI is saved only if:
+     * - it's a GET request
+     * - it has been initiated by the user navigating in the app
+     *
+     * The method does its best to exclude requests made with JavaScript.
+     * In particular, requests performed with the `fetch()` method must send
+     * the `X-Requested-With: XMLHttpRequest` header to be ignored by this
+     * method.
+     */
+    public function savePseudoReferrer(): void
+    {
+        $request = $this->requestStack->getCurrentRequest();
+        $session = $request->getSession();
+
+        $fetchMode = $request->headers->get('Sec-Fetch-Mode', 'navigate');
+        // If "navigate", the request is initiated by navigation between HTML
+        // documents. In our case, it can also be "cors" as Turbo loads pages
+        // with fetch requests.
+        $isMainNavigation = $fetchMode === 'navigate' || $fetchMode === 'cors';
+
+        $isTurboFrameRequest = $request->headers->get('turbo-frame') !== null;
+        $isJSRequest = $isTurboFrameRequest || $request->isXmlHttpRequest();
+
+        if ($request->isMethod('GET') && $isMainNavigation && !$isJSRequest) {
+            $session->set('_referrer', $request->getUri());
+        }
+    }
+
+    /**
+     * Return whether the given URL targets the current server.
+     *
+     * This is used to avoid attacks redirecting users to an external URL.
+     *
+     * Note that it doesn't check if the path is a valid route.
+     */
+    private function isSafeUrl(string $url): bool
+    {
+        $isHttpUrl = str_starts_with($url, 'http://') || str_starts_with($url, 'https://');
+        $isAbsolutePath = str_starts_with($url, '/') && !str_starts_with($url, '//');
+
+        if ($isHttpUrl) {
+            // If the URL is an HTTP(S) URL, make sure that it targets the application URL.
+            $appUrl = rtrim($this->appUrl, '/') . '/';
+            return str_starts_with($url, $appUrl);
+        } elseif ($isAbsolutePath) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
## Related issue(s)
<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

N/A

## How to test manually
<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Install the Referer Modifier addon https://addons.mozilla.org/en-US/firefox/addon/referer-modifier/
2. Configure it so the Referer header is removed when the domain target is "Same domain"
3. Go to AgentJ, select several messages and perform a batch action on them
4. Verify that you're redirected back to the previous page
5. Change the current locale, and check that it works too
5. Go to the list of users and change the number of paginated items, and check that it works too
6. Remove the addon and perform the tests again

## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works on both Firefox and Chrome
- [x] Tests are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
