### PR TITLE
chore: Add a flag to disable sorting by subject

### DIFF
--- a/app/.env.example
+++ b/app/.env.example
@@ -67,3 +67,10 @@ SENTRY_DSN='$SF_SENTRY_DSN'
 # with a lot of data. Until we optimize the SQL queries, you can disable the
 # dashboard to reduce server load.
 FEATURE_FLAG_DISABLE_DASHBOARD='$FEATURE_FLAG_DISABLE_DASHBOARD'
+
+# Disable sorting the messages by subject. Sorting by subject can be a heavy
+# operation requiring a dedicated index. However, we consider that specific
+# sort isn't really useful and don't justify adding an index on it. We
+# recommend to disable sorting by this column if you have a lot of data in
+# order to prevent users to run SQL requests that would DDoS the database.
+FEATURE_FLAG_DISABLE_SORT_BY_SUBJECT='$FEATURE_FLAG_DISABLE_SORT_BY_SUBJECT'

--- a/app/config/packages/twig.yaml
+++ b/app/config/packages/twig.yaml
@@ -12,6 +12,7 @@ twig:
         oauth_login_label: '%env(OAUTH_LOGIN_LABEL)%'
         azure_oauth_enabled: '%env(bool:ENABLE_AZURE_OAUTH)%'
         feature_flag_disable_dashboard: '%env(bool:FEATURE_FLAG_DISABLE_DASHBOARD)%'
+        feature_flag_disable_sort_by_subject: '%env(bool:FEATURE_FLAG_DISABLE_SORT_BY_SUBJECT)%'
         locales:
             - fr
             - en

--- a/app/docker/setup-env.sh
+++ b/app/docker/setup-env.sh
@@ -32,3 +32,4 @@ sed -i "s|\$TZ|$TZ|g" $env_file
 sed -i "s|\$DEFAULT_LOCALE|$DEFAULT_LOCALE|g" $env_file
 sed -i "s|\$HISTORY_RETENTION_DAYS|${HISTORY_RETENTION_DAYS:-30}|g" $env_file
 sed -i "s|\$FEATURE_FLAG_DISABLE_DASHBOARD|${FEATURE_FLAG_DISABLE_DASHBOARD:-false}|g" $env_file
+sed -i "s|\$FEATURE_FLAG_DISABLE_SORT_BY_SUBJECT|${FEATURE_FLAG_DISABLE_SORT_BY_SUBJECT:-false}|g" $env_file

--- a/app/src/Controller/MessageController.php
+++ b/app/src/Controller/MessageController.php
@@ -132,6 +132,11 @@ class MessageController extends AbstractController
                 'sort' => $request->query->getString('sort'),
                 'direction' => $request->query->getString('direction'),
             ];
+        } else {
+            $sortParams = [
+                'sort' => 'm.timeNum',
+                'direction' => 'desc',
+            ];
         }
 
         $searchKey = trim($request->query->getString('search'));
@@ -159,8 +164,6 @@ class MessageController extends AbstractController
                 'wrap-queries' => true,
                 'fetchJoinCollection' => false,
                 'distinct' => false,
-                'defaultSortFieldName' => 'm.timeNum',
-                'defaultSortDirection' => 'desc',
             ]
         );
         return $this->render('message/index.html.twig', [

--- a/app/src/Repository/MsgrcptSearchRepository.php
+++ b/app/src/Repository/MsgrcptSearchRepository.php
@@ -18,6 +18,7 @@ use Doctrine\ORM\QueryBuilder;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Tools\Pagination\Paginator;
 use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 /**
  * @extends BaseMessageRecipientRepository<Msgrcpt>
@@ -28,7 +29,9 @@ class MsgrcptSearchRepository extends BaseMessageRecipientRepository
 {
     public function __construct(
         ManagerRegistry $registry,
-        private UserRepository $userRepository
+        private UserRepository $userRepository,
+        #[Autowire(env: 'bool:FEATURE_FLAG_DISABLE_SORT_BY_SUBJECT')]
+        private bool $featureFlagDisableSortBySubject,
     ) {
         parent::__construct($registry, Msgrcpt::class);
     }
@@ -57,7 +60,10 @@ class MsgrcptSearchRepository extends BaseMessageRecipientRepository
         }
 
         if ($sortParams) {
-            $authorizedSortFields = ['m.timeNum', 'm.fromAddr', 'm.subject'];
+            $authorizedSortFields = ['m.timeNum', 'm.fromAddr'];
+            if (!$this->featureFlagDisableSortBySubject) {
+                $authorizedSortFields[] = 'm.subject';
+            }
             if ($user && $user->isAdmin()) {
                 $authorizedSortFields[] = 'maddr.email';
             }

--- a/app/src/Repository/MsgrcptSearchRepository.php
+++ b/app/src/Repository/MsgrcptSearchRepository.php
@@ -21,6 +21,8 @@ use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * @extends BaseMessageRecipientRepository<Msgrcpt>
+ *
+ * @phpstan-import-type SortParams from Search
  */
 class MsgrcptSearchRepository extends BaseMessageRecipientRepository
 {
@@ -32,7 +34,7 @@ class MsgrcptSearchRepository extends BaseMessageRecipientRepository
     }
 
     /**
-     * @param ?array{sort: string, direction: string} $sortParams
+     * @param ?SortParams $sortParams
      */
     public function getSearchQuery(
         ?User $user,
@@ -55,6 +57,13 @@ class MsgrcptSearchRepository extends BaseMessageRecipientRepository
         }
 
         if ($sortParams) {
+            $authorizedSortFields = ['m.timeNum', 'm.fromAddr', 'm.subject'];
+            if ($user && $user->isAdmin()) {
+                $authorizedSortFields[] = 'maddr.email';
+            }
+            $defaultSortField = 'm.timeNum';
+            $sortParams = Search::sanitizeSortParams($sortParams, $authorizedSortFields, $defaultSortField);
+
             $queryBuilder->orderBy($sortParams['sort'], $sortParams['direction']);
         }
 

--- a/app/src/Repository/MsgsRepository.php
+++ b/app/src/Repository/MsgsRepository.php
@@ -7,11 +7,14 @@ use App\Amavis\DeliveryStatus;
 use App\Amavis\MessageStatus;
 use App\Entity\Msgs;
 use App\Entity\User;
+use App\Util\Search;
 use Doctrine\DBAL;
 use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * @extends BaseMessageRepository<Msgs>
+ *
+ * @phpstan-import-type SortParams from Search
  */
 class MsgsRepository extends BaseMessageRepository
 {
@@ -29,10 +32,7 @@ class MsgsRepository extends BaseMessageRepository
     }
 
     /**
-     * @param ?array{
-     *     sort: string,
-     *     direction: string,
-     * } $sortParams
+     * @param ?SortParams $sortParams
      * @return array<int, array<string, mixed>>
      */
     public function advancedSearch(
@@ -102,18 +102,11 @@ class MsgsRepository extends BaseMessageRepository
         }
 
         if ($sortParams) {
-            $sortField = $sortParams['sort'];
-            $sortDirection = $sortParams['direction'];
+            $authorizedSortFields = ['mail_id', 'from_addr', 'email', 'subject', 'time_iso'];
+            $defaultSortField = 'm.time_num';
+            $sortParams = Search::sanitizeSortParams($sortParams, $authorizedSortFields, $defaultSortField);
 
-            if (!in_array($sortField, ['mail_id', 'from_addr', 'email', 'subject', 'time_iso'])) {
-                $sortField = 'm.time_num';
-            }
-
-            if ($sortDirection !== 'asc' && $sortDirection !== 'desc') {
-                $sortDirection = 'desc';
-            }
-
-            $sql .= " ORDER BY {$sortField} {$sortDirection}";
+            $sql .= " ORDER BY {$sortParams['sort']} {$sortParams['direction']}";
         } else {
             $sql .= ' ORDER BY m.time_num desc, m.status_id';
         }

--- a/app/src/Util/Search.php
+++ b/app/src/Util/Search.php
@@ -2,6 +2,14 @@
 
 namespace App\Util;
 
+/**
+ * Utility methods to ease building safe search requests.
+ *
+ * @phpstan-type SortParams array{
+ *     sort: string,
+ *     direction: string
+ * }
+ */
 class Search
 {
     /**
@@ -95,6 +103,35 @@ class Search
             'und',
             'the',
             'www',
+        ];
+    }
+
+    /**
+     * @param SortParams $sortParams
+     * @param string[] $authorizedSortFields
+     * @return SortParams
+     */
+    public static function sanitizeSortParams(
+        array $sortParams,
+        array $authorizedSortFields,
+        string $defaultSortField,
+    ): ?array {
+        $sortField = $sortParams['sort'];
+        $sortDirection = strtolower($sortParams['direction']);
+
+        $sortFieldIsAuthorized = in_array($sortField, $authorizedSortFields);
+
+        if (!$sortFieldIsAuthorized) {
+            $sortField = $defaultSortField;
+        }
+
+        if ($sortDirection !== 'asc' && $sortDirection !== 'desc') {
+            $sortDirection = 'desc';
+        }
+
+        return [
+            'sort' => $sortField,
+            'direction' => $sortDirection,
         ];
     }
 }

--- a/app/templates/message/index.html.twig
+++ b/app/templates/message/index.html.twig
@@ -40,7 +40,11 @@
                         {% endif %}
                         {#            <th>{{ 'Message.Status'|trans() }}</th> #}
                         <th>
-                            {{ knp_pagination_sortable(messagesRecipients, 'Message.Object'|trans, 'm.subject') }}
+                            {% if feature_flag_disable_sort_by_subject %}
+                                {{ 'Message.Object'|trans }}
+                            {% else %}
+                                {{ knp_pagination_sortable(messagesRecipients, 'Message.Object'|trans, 'm.subject') }}
+                            {% endif %}
                         </th>
                         <th>
                             {{ knp_pagination_sortable(messagesRecipients, 'Message.Sender'|trans, 'm.fromAddr') }}


### PR DESCRIPTION
## Related issue(s)
<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

N/A

## How to test manually
<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

- set `FEATURE_FLAG_DISABLE_SORT_BY_SUBJECT=true` in the `.env` file
- open list of messages
- verify that you cannot sort by subject

## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works on both Firefox and Chrome
- [x] Tests are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
