### PR TITLE
feat: Allow to include spams in the report

### DIFF
--- a/app/assets/controllers/slider_controller.js
+++ b/app/assets/controllers/slider_controller.js
@@ -1,0 +1,13 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+    static targets = ["slider", "output"]
+
+    connect() {
+        this.refresh();
+    }
+
+    refresh() {
+        this.outputTarget.innerHTML = this.sliderTarget.value;
+    }
+}

--- a/app/migrations/Version20260303170142.php
+++ b/app/migrations/Version20260303170142.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260303170142 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add report_spam_level to domain table.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE domain ADD report_spam_level DOUBLE PRECISION DEFAULT \'0\' NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE domain DROP report_spam_level');
+    }
+}

--- a/app/public/js/agentj.js
+++ b/app/public/js/agentj.js
@@ -189,21 +189,6 @@ document.addEventListener("turbo:load", function () {
     $(this).next('.custom-file-label').html(fileName);
   });
 
-  // range input management
-  var slider = $("#domain_level");
-  var output = $("#domain-spam-level");
-  output.innerHTML = slider.value; // Display the default slider value
-
-  $(document).on('input', '#domain_level', function (e) {
-    $("#domain-spam-level").html($(this).val());
-
-  });
-
-  // Update the current slider value (each time you drag the slider handle)
-  slider.oninput = function () {
-    output.innerHTML = this.value;
-  }
-
 
   $('#resultsPerPage, #massive-actions-form_per_page').change(function () {
     var url = $(location).attr('pathname') + $(location).attr('search').replace('page=' + $_GET('page'), 'page=1');

--- a/app/src/Command/ReportSendMailCommand.php
+++ b/app/src/Command/ReportSendMailCommand.php
@@ -66,16 +66,13 @@ class ReportSendMailCommand extends Command
                 continue;
             }
 
-            $untreatedMessageRecipients = $this->msgrcptSearchRepository->getSearchQuery(
-                $user,
-                fromDate: $user->getDateLastReport()
-            )->getResult();
+            $messageRecipients = $this->getMessageRecipients($user);
 
-            if (count($untreatedMessageRecipients) === 0) {
+            if (count($messageRecipients) === 0) {
                 continue;
             }
 
-            $body = $this->createEmailContent($user, $untreatedMessageRecipients);
+            $body = $this->createEmailContent($user, $messageRecipients);
 
             $domain = $user->getDomain();
             $from = $domain->getMailAuthenticationSender();
@@ -134,11 +131,11 @@ class ReportSendMailCommand extends Command
     }
 
     /**
-     * @param Msgrcpt[] $untreatedMessageRecipients
+     * @param Msgrcpt[] $messageRecipients
      */
-    private function createEmailContent(User $user, array $untreatedMessageRecipients): string
+    private function createEmailContent(User $user, array $messageRecipients): string
     {
-        $untreatedMessageRecipients = array_slice($untreatedMessageRecipients, 0, 10);
+        $messageRecipients = array_slice($messageRecipients, 0, 10);
         $nbUntreated = $this->msgrcptSearchRepository->countByType($user, MessageStatus::UNTREATED);
         $nbAuthorized = $this->msgrcptSearchRepository->countByType($user, MessageStatus::AUTHORIZED);
         $nbBanned = $this->msgrcptSearchRepository->countByType($user, MessageStatus::BANNED);
@@ -156,7 +153,7 @@ class ReportSendMailCommand extends Command
         }
 
         $tableMessages = $this->twig->render('report/table_mail_msgs.html.twig', [
-            'untreatedMessageRecipients' => $untreatedMessageRecipients,
+            'messageRecipients' => $messageRecipients,
             'user' => $user,
             'locale' => $locale,
         ]);
@@ -173,18 +170,18 @@ class ReportSendMailCommand extends Command
         $body = str_replace('[NB_DELETED_MESSAGES]', (string) $nbDeleted, $body);
         $body = str_replace('[URL_MSGS]', $url, $body);
 
-        $body = $this->replaceForeachMessages($body, $user, $untreatedMessageRecipients);
+        $body = $this->replaceForeachMessages($body, $user, $messageRecipients);
 
         return $body;
     }
 
     /**
-     * @param Msgrcpt[] $untreatedMessageRecipients
+     * @param Msgrcpt[] $messageRecipients
      */
     private function replaceForeachMessages(
         string $body,
         User $user,
-        array $untreatedMessageRecipients
+        array $messageRecipients
     ): string {
         // Get the part of the body before [FOREACH_MESSAGE].
         $splittedBody = explode('[FOREACH_MESSAGE]', $body, 2);
@@ -211,7 +208,7 @@ class ReportSendMailCommand extends Command
         $messageTemplate = $splittedBody[0];
 
         $bodyMessages = '';
-        foreach ($untreatedMessageRecipients as $messageRecipient) {
+        foreach ($messageRecipients as $messageRecipient) {
             $message = $messageRecipient->getMsgs();
             $token = $this->messageService->getReleaseToken($message, $user);
 
@@ -239,5 +236,33 @@ class ReportSendMailCommand extends Command
         }
 
         return $bodyStart . $bodyMessages . $bodyEnd;
+    }
+
+    /**
+     * @return Msgrcpt[]
+     */
+    private function getMessageRecipients(User $user): array
+    {
+        $messageRecipients = $this->msgrcptSearchRepository->getSearchQuery(
+            $user,
+            messageStatus: MessageStatus::UNTREATED,
+            fromDate: $user->getDateLastReport(),
+        )->getResult();
+
+        $domain = $user->getDomain();
+        $reportSpamLevel = $domain->getReportSpamLevel();
+
+        if ($reportSpamLevel > 0) {
+            $spamMessageRecipients = $this->msgrcptSearchRepository->getSearchQuery(
+                $user,
+                messageStatus: MessageStatus::SPAMMED,
+                maxSpamLevel: $reportSpamLevel,
+                fromDate: $user->getDateLastReport(),
+            )->getResult();
+
+            $messageRecipients = array_merge($messageRecipients, $spamMessageRecipients);
+        }
+
+        return $messageRecipients;
     }
 }

--- a/app/src/Controller/DomainController.php
+++ b/app/src/Controller/DomainController.php
@@ -190,13 +190,13 @@ class DomainController extends AbstractController
 
             return $this->redirectToRoute('domain_new');
         } else {
-            $form->get('level')->setData(0.5);
+            $defaultSpamLevel = $this->getParameter('app.domain_default_spam_level');
+            $form->get('level')->setData($defaultSpamLevel);
         }
 
         return $this->render('domain/new.html.twig', [
             'domain' => $domain,
             'form' => $form->createView(),
-            'domainSpamLevel' => $this->getParameter('app.domain_default_spam_level')
         ]);
     }
 

--- a/app/src/Entity/Domain.php
+++ b/app/src/Entity/Domain.php
@@ -68,6 +68,9 @@ class Domain
     #[ORM\Column(type: Types::TEXT, options: ['default' => ''])]
     private string $humanAuthenticationFooter = '';
 
+    #[ORM\Column(options: ['default' => 0])]
+    private float $reportSpamLevel = 0;
+
     /**
      * @var Collection<int, Groups>
      */
@@ -303,6 +306,18 @@ class Domain
     public function setHumanAuthenticationFooter(string $humanAuthenticationFooter): static
     {
         $this->humanAuthenticationFooter = $humanAuthenticationFooter;
+
+        return $this;
+    }
+
+    public function getReportSpamLevel(): ?float
+    {
+        return $this->reportSpamLevel;
+    }
+
+    public function setReportSpamLevel(float $reportSpamLevel): static
+    {
+        $this->reportSpamLevel = $reportSpamLevel;
 
         return $this;
     }

--- a/app/src/Form/DomainCustomisationReportType.php
+++ b/app/src/Form/DomainCustomisationReportType.php
@@ -4,6 +4,7 @@ namespace App\Form;
 
 use App\Entity\Domain;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\RangeType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -16,6 +17,17 @@ class DomainCustomisationReportType extends AbstractType
             'label' => 'Entities.Domain.fields.messageAlert',
             'attr' => [
                 'data-controller' => 'ckeditor',
+            ],
+        ]);
+
+        $builder->add('reportSpamLevel', RangeType::class, [
+            'label' => 'Entities.Domain.fields.reportSpamLevel',
+            'attr' => [
+                'min' => 0,
+                'max' => 10,
+                'step' => 0.1,
+                'data-slider-target' => 'slider',
+                'data-action' => 'slider#refresh',
             ],
         ]);
     }

--- a/app/src/Form/DomainType.php
+++ b/app/src/Form/DomainType.php
@@ -56,7 +56,9 @@ class DomainType extends AbstractType
                 'attr' => [
                     'min' => $options['minSpamLevel'],
                     'max' => $options['maxSpamLevel'],
-                    'step' => 0.1
+                    'step' => 0.1,
+                    'data-slider-target' => 'slider',
+                    'data-action' => 'slider#refresh',
                 ]
             ])
             ->add('mailAuthenticationSender', null, [

--- a/app/src/Repository/MsgrcptSearchRepository.php
+++ b/app/src/Repository/MsgrcptSearchRepository.php
@@ -47,7 +47,8 @@ class MsgrcptSearchRepository extends BaseMessageRecipientRepository
         ?int $messageStatus = MessageStatus::UNTREATED,
         ?string $searchKey = null,
         ?array $sortParams = null,
-        ?int $fromDate = null
+        ?int $fromDate = null,
+        ?float $maxSpamLevel = null,
     ): Query {
 
         $queryBuilder = $this->getSearchQueryBuilder($user, $messageStatus);
@@ -59,6 +60,11 @@ class MsgrcptSearchRepository extends BaseMessageRecipientRepository
         if (!is_null($fromDate)) {
             $queryBuilder->andWhere('m.timeNum > :date');
             $queryBuilder->setParameter('date', $fromDate);
+        }
+
+        if (!is_null($maxSpamLevel)) {
+            $queryBuilder->andWhere('mr.bspamLevel <= :maxSpamLevel');
+            $queryBuilder->setParameter('maxSpamLevel', $maxSpamLevel);
         }
 
         if ($sortParams) {

--- a/app/templates/domain/_form.html.twig
+++ b/app/templates/domain/_form.html.twig
@@ -206,10 +206,14 @@
 
             {{ form_row(form.rules) }}
             {{ form_row(form.policy) }}
-            <div class="form-group row">
-                <label for="domain_level" class="col-sm-12">{{ 'Entities.Domain.fields.level'|trans }} : <span
-                            id="domain-spam-level">{{ domainSpamLevel }}</span></label>
-                <div class="col-sm-12">{{ form_widget(form.level) }}</div>
+
+            <div class="form-group" data-controller="slider">
+                <label for="{{ field_id(form.level) }}" class="col-sm-12 col-form-label col-form-label col-sm-2 required">
+                    {{ field_label(form.level) }} :
+                    <span data-slider-target="output"></span>
+                </label>
+
+                {{ form_widget(form.level) }}
             </div>
 
             <div class="form-group">

--- a/app/templates/domain/customisation/report.html.twig
+++ b/app/templates/domain/customisation/report.html.twig
@@ -9,6 +9,15 @@
         <div class="row">
             <div class="col-9">
                 {{ form_row(form.messageAlert) }}
+
+                <div class="form-group" data-controller="slider">
+                    <label for="{{ field_id(form.reportSpamLevel) }}" class="col-sm-12 col-form-label col-form-label col-sm-2 required">
+                        {{ field_label(form.reportSpamLevel) }}
+                        <span data-slider-target="output"></span>
+                    </label>
+
+                    {{ form_widget(form.reportSpamLevel) }}
+                </div>
             </div>
 
             <div class="col-3">

--- a/app/templates/report/table_mail_msgs.html.twig
+++ b/app/templates/report/table_mail_msgs.html.twig
@@ -1,7 +1,7 @@
-{% if untreatedMessageRecipients is not empty %}
+{% if messageRecipients is not empty %}
   <table style="width:100%;background-color: #fff;">
     <tbody>
-      {% for messageRecipient in untreatedMessageRecipients %}
+      {% for messageRecipient in messageRecipients %}
         {% set token = message_release_token(messageRecipient.msgs, user) %}
         <tr>
 

--- a/app/translations/messages.en.yml
+++ b/app/translations/messages.en.yml
@@ -479,6 +479,7 @@ Entities:
       humanAuthenticationFooter: "Footer of the human authentication page"
       humanAuthenticationStylesheet: "Custom stylesheet on the human authentication page"
       messageAlert: "Message of the report"
+      reportSpamLevel: 'Include spam in the report whose level is lower than:'
       domain: "Domain name"
       srvSmtp: "SMTP server"
       srvImap: "IMAP server"

--- a/app/translations/messages.fr.yml
+++ b/app/translations/messages.fr.yml
@@ -479,6 +479,7 @@ Entities:
       humanAuthenticationFooter: Pied de page de la page d'authentification humaine
       humanAuthenticationStylesheet: Feuille de style personnalisée de la page d'authentification humaine
       messageAlert: Message du rapport
+      reportSpamLevel: "Inclure les spams au rapport dont le niveau est inférieur à\_:"
       domain: Nom de domaine
       srvSmtp: Serveur SMTP
       srvImap: Serveur IMAP


### PR DESCRIPTION
## Related issue(s)
<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

N/A

## How to test manually
<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Customise the report to include spams with level under 5. Make sure the report content includes `[LIST_MAIL_MSGS]` too.
2. Send three mail to AgentJ (`./scripts/mail_to_agentj.sh`)
3. In the database (`./scripts/mariadb agentj`), update one of them to be a spam with a level under 5 (`update msgrcpt set bspam_level=4.0, status_id=6 where mail_id='[MAIL_ID]';`)
3. Update another one to be a spam with a level above 5 (`update msgrcpt set bspam_level=6.0, status_id=6 where mail_id='[MAIL_ID]';`)
4. Send the report `./scripts/console agentj:report-send-mail`
5. Check that the report contains 2 mails: the one which is not spam should be first, and the spam with level 4 should be second.

## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [ ] Code is manually tested
- [ ] Interface works on both mobiles and big screens
- [ ] Interface works on both Firefox and Chrome
- [ ] Tests are up to date
- [ ] Documentation is up to date
- [ ] Pull request has been reviewed and approved
