### PR TITLE
fix: Fix getting messages for super-admins attached to domains

### DIFF
--- a/app/src/Entity/User.php
+++ b/app/src/Entity/User.php
@@ -678,11 +678,23 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
         return $this;
     }
 
-    public function isAdmin(): bool
+    /**
+     * Return whether the user is an admin or not.
+     *
+     * If $superAdmin is true (default), then a super-admin is considered as
+     * admin. If it is false, the method returns false for super-admins.
+     */
+    public function isAdmin(bool $superAdmin = true): bool
     {
-        return in_array('ROLE_ADMIN', $this->getRoles()) || in_array('ROLE_SUPER_ADMIN', $this->getRoles());
+        return (
+            in_array('ROLE_ADMIN', $this->getRoles()) ||
+            ($superAdmin && $this->isSuperAdmin())
+        );
     }
 
+    /**
+     * Return whether the user is a super-admin or not.
+     */
     public function isSuperAdmin(): bool
     {
         return in_array('ROLE_SUPER_ADMIN', $this->getRoles());

--- a/app/src/Repository/MsgrcptSearchRepository.php
+++ b/app/src/Repository/MsgrcptSearchRepository.php
@@ -191,11 +191,15 @@ class MsgrcptSearchRepository extends BaseMessageRecipientRepository
     ): QueryBuilder {
         $queryBuilder = $this->getBaseQueryBuilder();
 
-        $this->addUserSpecificJoins($queryBuilder, $user);
-
-        if ($user?->isAdmin()) {
-            $this->addDomainCondition($queryBuilder, $user);
-        } elseif ($user) {
+        if ($user && $user->isAdmin(superAdmin: false)) {
+            // Filter messages on corresponding domains for simple admins as
+            // they must not have access to all the messages.
+            $this->addUserSpecificJoins($queryBuilder, $user);
+            $queryBuilder->andWhere('u.domain in (:domain)');
+            $queryBuilder->setParameter('domain', $user->getDomains());
+        } elseif ($user && !$user->isAdmin()) {
+            // If the user is a standard user, filter messages by his email
+            // addresses (including aliases).
             $this->addRecipientsCondition($queryBuilder, $user);
         }
 
@@ -207,7 +211,7 @@ class MsgrcptSearchRepository extends BaseMessageRecipientRepository
 
     private function addUserSpecificJoins(QueryBuilder $queryBuilder, ?User $user): void
     {
-        if ($user && $user->isAdmin() && !$user->isSuperAdmin()) {
+        if ($user && $user->isAdmin(superAdmin: false)) {
             // Users table is only used to filter the messages by the domains
             // of a "simple" admin. As super-admins have access to all the
             // domains, we don't need it in this case.
@@ -261,14 +265,6 @@ class MsgrcptSearchRepository extends BaseMessageRecipientRepository
 
             $queryBuilder->andWhere('(maddr.email IN (:users) OR maddrSender.email IN (:users))');
             $queryBuilder->setParameter('users', $allUserEmails);
-        }
-    }
-
-    private function addDomainCondition(QueryBuilder $queryBuilder, User $user): void
-    {
-        if (count($user->getDomains()) > 0) {
-            $queryBuilder->andWhere('u.domain in (:domain)')
-                ->setParameter('domain', $user->getDomains());
         }
     }
 


### PR DESCRIPTION
## Related issue(s)
<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

N/A

## How to test manually
<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Update the super-admin (he should now be associated to all the domains)
2. Go to the list of messages and check that the list is displayed

## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works on both Firefox and Chrome
- [x] Tests are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
