### PR TITLE
fix: Store locks in database 

### DIFF
--- a/app/config/packages/lock.yaml
+++ b/app/config/packages/lock.yaml
@@ -1,2 +1,2 @@
 framework:
-    # lock: '%env(LOCK_DSN)%'
+    lock: '%env(DATABASE_URL)%'

--- a/app/migrations/Version20260318095554.php
+++ b/app/migrations/Version20260318095554.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+// phpcs:disable Generic.Files.LineLength
+final class Version20260318095554 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create the lock_keys table.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE IF NOT EXISTS lock_keys (key_id VARCHAR(64) NOT NULL, key_token VARCHAR(44) NOT NULL, key_expiration INT UNSIGNED NOT NULL, PRIMARY KEY(key_id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE lock_keys');
+    }
+}

--- a/app/src/Command/AmavisAutoReleaseCommand.php
+++ b/app/src/Command/AmavisAutoReleaseCommand.php
@@ -12,7 +12,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Lock\LockFactory;
-use Symfony\Component\Lock\Store\SemaphoreStore;
 
 #[AsCommand(
     name: 'agentj:auto-release-message',
@@ -26,6 +25,7 @@ class AmavisAutoReleaseCommand extends Command
         private MsgrcptSearchRepository $msgrcptSearchRepository,
         private UserRepository $userRepository,
         private MessageService $messageService,
+        private LockFactory $lockFactory,
     ) {
         parent::__construct();
     }
@@ -34,9 +34,7 @@ class AmavisAutoReleaseCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
 
-        $store = new SemaphoreStore();
-        $factory = new LockFactory($store);
-        $lock = $factory->createLock('msgs-auto-release', 1800);
+        $lock = $this->lockFactory->createLock('msgs-auto-release', ttl: 1800);
 
         if (!$lock->acquire()) {
             $output->writeln("Can't acquire the msgs-auto-release lock, the command is probably already running.");

--- a/app/src/Command/SendAuthMailRequestCommand.php
+++ b/app/src/Command/SendAuthMailRequestCommand.php
@@ -17,7 +17,6 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Lock\LockFactory;
-use Symfony\Component\Lock\Store\SemaphoreStore;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -40,6 +39,7 @@ class SendAuthMailRequestCommand extends Command
         private MailerInterface $mailer,
         private UrlGeneratorInterface $urlGenerator,
         private LocaleService $localeService,
+        private LockFactory $lockFactory,
         #[Autowire(param: 'app.amavisd-release')]
         public readonly string $amavisdRelease,
         #[Autowire(param: 'app.domain_mail_authentification_sender')]
@@ -50,9 +50,7 @@ class SendAuthMailRequestCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $store = new SemaphoreStore();
-        $factory = new LockFactory($store);
-        $lock = $factory->createLock('msgs-send-mail-token', 1800);
+        $lock = $this->lockFactory->createLock('msgs-send-mail-token', ttl: 1800);
 
         if (!$lock->acquire()) {
             $output->writeln("Can't acquire the msgs-send-mail-token lock, the command is probably already running.");

--- a/app/src/MessageHandler/AmavisReleaseHandler.php
+++ b/app/src/MessageHandler/AmavisReleaseHandler.php
@@ -8,6 +8,7 @@ use App\Repository\MsgrcptRepository;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\Process\Process;
 
 #[AsMessageHandler]
@@ -18,6 +19,7 @@ final class AmavisReleaseHandler
         private string $amavisdReleaseCommand,
         private MsgrcptRepository $messageRecipientRepository,
         private LoggerInterface $logger,
+        private LockFactory $lockFactory,
     ) {
     }
 
@@ -67,6 +69,19 @@ final class AmavisReleaseHandler
             return;
         }
 
+        $lockName = (
+            'amavis-release'
+            . "-{$amavisRelease->getPartitionTag()}"
+            . "-{$amavisRelease->getMailId()}"
+            . "-{$amavisRelease->getRseqnum()}"
+        );
+        $lock = $this->lockFactory->createLock($lockName, ttl: 10 * 60);
+
+        if (!$lock->acquire()) {
+            $this->logger->info("Can't acquire the {$lockName} lock, the release is probably already running.");
+            return;
+        }
+
         $process = new Process([
             $this->amavisdReleaseCommand,
             $messageRecipient->getMsgs()->getQuarLoc(),
@@ -97,5 +112,7 @@ final class AmavisReleaseHandler
 
         $messageRecipient->setAmavisReleaseEndedAt(new \DateTimeImmutable());
         $this->messageRecipientRepository->save($messageRecipient);
+
+        $lock->release();
     }
 }

--- a/app/src/MessageHandler/ConsolidateAmavisDataHandler.php
+++ b/app/src/MessageHandler/ConsolidateAmavisDataHandler.php
@@ -7,7 +7,6 @@ use App\Repository\MsgrcptRepository;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Lock\LockFactory;
-use Symfony\Component\Lock\Store\SemaphoreStore;
 
 #[AsMessageHandler]
 final class ConsolidateAmavisDataHandler
@@ -15,17 +14,16 @@ final class ConsolidateAmavisDataHandler
     public function __construct(
         private MsgrcptRepository $messageRecipientRepository,
         private LoggerInterface $logger,
+        private LockFactory $lockFactory,
     ) {
     }
 
     public function __invoke(ConsolidateAmavisData $consolidateAmavisData): void
     {
-        $store = new SemaphoreStore();
-        $factory = new LockFactory($store);
-        $lock = $factory->createLock('consolidate-amavis-data', 15 * 60);
+        $lock = $this->lockFactory->createLock('consolidate-amavis-data', ttl: 15 * 60);
 
         if (!$lock->acquire()) {
-            $this->logger->error("Can't acquire the consolidate-amavis-data lock, an update is already running.");
+            $this->logger->info("Can't acquire the consolidate-amavis-data lock, an update is already running.");
             return;
         }
 

--- a/app/src/MessageHandler/SynchronizeConnectorsHandler.php
+++ b/app/src/MessageHandler/SynchronizeConnectorsHandler.php
@@ -15,7 +15,6 @@ use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Lock\LockFactory;
-use Symfony\Component\Lock\Store\SemaphoreStore;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
 #[AsMessageHandler]
@@ -27,19 +26,18 @@ final class SynchronizeConnectorsHandler
         KernelInterface $kernel,
         private ConnectorRepository $connectorRepository,
         private LoggerInterface $logger,
-        private EntityManagerInterface $entityManager
+        private EntityManagerInterface $entityManager,
+        private LockFactory $lockFactory,
     ) {
         $this->application = new Application($kernel);
     }
 
     public function __invoke(SynchronizeConnectors $message): void
     {
-        $store = new SemaphoreStore();
-        $factory = new LockFactory($store);
-        $lock = $factory->createLock('synchronize-connectors', ttl: 3600);
+        $lock = $this->lockFactory->createLock('synchronize-connectors', ttl: 3600);
 
         if (!$lock->acquire()) {
-            $this->logger->warning(
+            $this->logger->info(
                 'Cannot acquire the synchronize-connectors lock, the handler is probably already running.'
             );
             return;


### PR DESCRIPTION
## Related issue(s)
<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

N/A

## How to test manually
<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. run several workers in parallel: `docker compose up -d --scale worker=3`
2. disable human auth for the `user@blocnormal.fr` user
3. send emails to this user: `./scripts/mail_to_agentj.sh`
4. make sure the email is delivered automatically **only once** to the user by checking http://localhost:8025/ (wait a bit, it should be released within a minute or two)
5. verify in the logs that there are infos about locks that can't be acquired (you may need to set the following env var `SCHEDULER_CONSOLIDATE_FREQUENCY='5 seconds'` to be sure to see the infos)

## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works on both Firefox and Chrome
- [x] Tests are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
