### PR TITLE
Add option to disable antispoofing for outgoing emails

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -105,6 +105,13 @@ SF_TOKEN_ENCRYPTION_SALT=
 # You'll have to put the cert file in the sslcerts Docker volume, under the name fullchain.pem
 #SMTPD_ENABLE_TLS=false
 
+# Disable antispoofing for outgoing emails
+# By default, for outgoing emails, AgentJ will check that the sender's email address exists in the
+# AgentJ database. If not, the email will be rejected. In some cases, this behavior can't be
+# enforced as on some infrastructure there is no exhaustive list of emails addresses that can send
+# emails. In this case only the sender's domain will be checked.
+#DISABLE_OUTGOING_ANTISPOOFING_PROTECTION=false
+
 # Variables for dev (if using compose.dev.yml)
 
 # expose db on the host

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -165,6 +165,7 @@ services:
       - DB_HOST
       - DB_NAME
       - DB_PASSWORD=$DB_OPENDKIM_PASSWORD
+      - DISABLE_OUTGOING_ANTISPOOFING_PROTECTION
     depends_on:
       db:
         condition: service_healthy

--- a/senderverifmilter/handler.py
+++ b/senderverifmilter/handler.py
@@ -1,4 +1,4 @@
-
+import os
 
 class Handler:
     """Handle request"""
@@ -46,15 +46,28 @@ class Handler:
 
         self.db = self.db_pool.connection()
         self.cursor = self.db.cursor()
-        self.cursor.execute(
+        # If the antispoofing protection is disabled we only check the domain, not the full email
+        # address
+        if os.environ.get('DISABLE_OUTGOING_ANTISPOOFING_PROTECTION') == "true":
+            self.cursor.execute(
                 '''
-                select 1 from domain a
-                join domain_relay b on a.id = b.domain_id
-                join users c on a.id = c.domain_id
-                where b.ip_address = %s and c.email = %s
+                select 1 from domain d
+                join domain_relay dr on d.id = dr.domain_id
+                where dr.ip_address = %s and d.domain = %s
+                ''',
+                (request['client_address'], request['sender'].split("@")[1])
+            )
+        else:
+            self.cursor.execute(
+                '''
+                select 1 from domain d
+                join domain_relay dr on d.id = dr.domain_id
+                join users u on d.id = u.domain_id
+                where dr.ip_address = %s and u.email = %s
                 ''',
                 (request['client_address'], request['sender'])
-                )
+            )
+
         result = self.cursor.fetchone()
         if result is None:
             print('INVALID sender/ip pair:', request['client_address'], request['sender'])


### PR DESCRIPTION
## Related issue(s)
<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

## How to test manually
<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->
Try to send an outgoing email through AgentJ. By default if the sender is not an user of AgentJ, the email will be rejected. Enable `DISABLE_OUTGOING_ANTISPOOFING_PROTECTION` and try again, with an email not registered in AgentJ but on a domain managed by AgentJ and the email will not be rejected.

## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works on both Firefox and Chrome
- [x] Tests are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
