### PR TITLE
feat(app): Allow admins to mark messages as spam/ham

### DIFF
--- a/app/src/Command/MessageMarkAsCommand.php
+++ b/app/src/Command/MessageMarkAsCommand.php
@@ -4,14 +4,12 @@ namespace App\Command;
 
 use App\Amavis\MessageStatus;
 use App\Repository\MsgsRepository;
-use App\Repository\MsgrcptRepository;
 use App\Service\MessageService;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Attribute\Argument;
 use Symfony\Component\Console\Attribute\Option;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 #[AsCommand(
     name: 'agentj:messages:mark-as',
@@ -21,10 +19,7 @@ class MessageMarkAsCommand
 {
     public function __construct(
         private MsgsRepository $messageRepository,
-        private MsgrcptRepository $messageRecipientRepository,
         private MessageService $messageService,
-        #[Autowire(param: 'app.spamassassin_learn_dir')]
-        private string $spamassassinLearnDir,
     ) {
     }
 
@@ -49,48 +44,20 @@ class MessageMarkAsCommand
             return Command::FAILURE;
         }
 
+        $output->write("Marking the message as {$status}... ");
+
         if ($status === 'spam') {
-            $markDirName = 'spams';
+            $result = $this->messageService->markMessageAsSpam($message);
         } else {
-            $markDirName = 'hams';
+            $result = $this->messageService->markMessageAsHam($message);
         }
 
-        $output->write('Putting the message in the SpamAssassin learning directory… ');
-
-        $outputDirPath = "{$this->spamassassinLearnDir}/{$markDirName}";
-        if (!is_dir($outputDirPath)) {
-            mkdir($outputDirPath);
+        if ($result) {
+            $output->writeln('ok');
+            return Command::SUCCESS;
+        } else {
+            $output->writeln('error');
+            return Command::FAILURE;
         }
-
-        $content = $message->getQuarantineContent();
-
-        $fileName = "{$message->getMailId()}.eml";
-        $filePath = "{$outputDirPath}/{$fileName}";
-
-        file_put_contents($filePath, $content);
-
-        $output->writeln('ok');
-
-        foreach ($message->getMsgRcpts() as $messageRecipient) {
-            $recipient = $messageRecipient->getRid();
-            $recipientEmail = $recipient->getEmailClear();
-
-            if ($messageRecipient->isUntreated() && $status === 'spam') {
-                $output->write("Moving the message to spams for {$recipientEmail}… ");
-
-                $messageRecipient->setStatus(MessageStatus::SPAMMED);
-                $this->messageRecipientRepository->save($messageRecipient);
-
-                $output->writeln('ok');
-            } elseif ($messageRecipient->isSpam() && $status === 'ham') {
-                $output->write("Restoring the message for {$recipientEmail}… ");
-
-                $this->messageService->restore($messageRecipient);
-
-                $output->writeln('ok');
-            }
-        }
-
-        return Command::SUCCESS;
     }
 }

--- a/app/src/Controller/MessageController.php
+++ b/app/src/Controller/MessageController.php
@@ -60,6 +60,9 @@ class MessageController extends AbstractController
                         'Message.Actions.Banned' => 'banned',
                         'Message.Actions.Delete' => 'delete',
                     ];
+                    if ($this->isGranted('ROLE_ADMIN')) {
+                        $messageActions['Message.Actions.MarkAsHam'] = 'mark as ham';
+                    }
                     $messageStatus = MessageStatus::SPAMMED;
                     break;
                 case 'virus':
@@ -100,6 +103,10 @@ class MessageController extends AbstractController
                         'Message.Actions.Banned' => 'banned',
                         'Message.Actions.Delete' => 'delete',
                     ];
+                    if ($this->isGranted('ROLE_ADMIN')) {
+                        $messageActions['Message.Actions.MarkAsSpam'] = 'mark as spam';
+                    }
+
                     $messageStatus = MessageStatus::UNTREATED;
                     break;
             }
@@ -110,6 +117,10 @@ class MessageController extends AbstractController
                 'Message.Actions.Banned' => 'banned',
                 'Message.Actions.Delete' => 'delete',
             ];
+            if ($this->isGranted('ROLE_ADMIN')) {
+                $messageActions['Message.Actions.MarkAsSpam'] = 'mark as spam';
+            }
+
             $subTitle = 'Entities.Message.untreated';
             $messageStatus = MessageStatus::UNTREATED;
         }
@@ -292,6 +303,16 @@ class MessageController extends AbstractController
                         $this->messageService->dispatchRelease($messageRecipient);
                         $logService->addLog('restore batch', $mailId);
                         break;
+                    case 'mark as spam':
+                        $message = $messageRecipient->getMsgs();
+                        $this->messageService->markMessageAsSpam($message);
+                        $logService->addLog('marked as spam batch', $mailId);
+                        break;
+                    case 'mark as ham':
+                        $message = $messageRecipient->getMsgs();
+                        $this->messageService->markMessageAsHam($message);
+                        $logService->addLog('marked as ham batch', $mailId);
+                        break;
                 }
             }
         }
@@ -412,6 +433,46 @@ class MessageController extends AbstractController
         if ($result) {
             $this->addFlash('success', $this->translator->trans('Message.Flash.senderBanned'));
             $logService->addLog('banned for domain', $messageRecipient->getMailIdAsString());
+        }
+
+        return new RedirectResponse($this->referrer->get());
+    }
+
+    #[IsGranted('ROLE_ADMIN')]
+    #[Route(path: '/{partitionTag}/{mailId}/{rid}/markAsSpam', name: 'message_mark_as_spam')]
+    public function markAsSpam(
+        Msgrcpt $messageRecipient,
+        Request $request,
+        Service\LogService $logService,
+    ): RedirectResponse {
+        $this->checkMailAccess($messageRecipient);
+
+        $message = $messageRecipient->getMsgs();
+        $result = $this->messageService->markMessageAsSpam($message);
+
+        if ($result) {
+            $this->addFlash('success', $this->translator->trans('Message.Flash.messageMarkedAsSpam'));
+            $logService->addLog('marked as spam', $message->getMailId());
+        }
+
+        return new RedirectResponse($this->referrer->get());
+    }
+
+    #[IsGranted('ROLE_ADMIN')]
+    #[Route(path: '/{partitionTag}/{mailId}/{rid}/markAsHam', name: 'message_mark_as_ham')]
+    public function markAsHam(
+        Msgrcpt $messageRecipient,
+        Request $request,
+        Service\LogService $logService,
+    ): RedirectResponse {
+        $this->checkMailAccess($messageRecipient);
+
+        $message = $messageRecipient->getMsgs();
+        $result = $this->messageService->markMessageAsHam($message);
+
+        if ($result) {
+            $this->addFlash('success', $this->translator->trans('Message.Flash.messageMarkedAsHam'));
+            $logService->addLog('marked as ham', $message->getMailId());
         }
 
         return new RedirectResponse($this->referrer->get());

--- a/app/src/Service/MessageService.php
+++ b/app/src/Service/MessageService.php
@@ -31,6 +31,7 @@ class MessageService
         private UserRepository $userRepository,
         private WblistRepository $wblistRepository,
         private CryptEncryptService $cryptEncryptService,
+        private SpamassassinService $spamassassinService,
     ) {
     }
 
@@ -256,6 +257,59 @@ class MessageService
         );
 
         return true;
+    }
+
+    /**
+     * Mark a message as spam.
+     *
+     * Marking a message as spam put the message in a "spams" folder so
+     * Spamassassin will learn with Bayes classifier. It also moves the message
+     * to the "spam" menu for each recipient that would have it in "untreated"
+     * menu.
+     *
+     * It returns false if the message couldn't be put in the spams folder.
+     */
+    public function markMessageAsSpam(Msgs $message): bool
+    {
+        $result = $this->spamassassinService->marksAsSpam($message);
+
+        foreach ($message->getMsgRcpts() as $messageRecipient) {
+            if (!$messageRecipient->isUntreated()) {
+                continue;
+            }
+
+            $recipient = $messageRecipient->getRid();
+            $recipientEmail = $recipient->getEmailClear();
+
+            $messageRecipient->setStatus(MessageStatus::SPAMMED);
+            $this->messageRecipientRepository->save($messageRecipient);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Mark a message as ham.
+     *
+     * Marking a message as ham put the message in a "hams" folder so
+     * Spamassassin will learn with Bayes classifier. It also restores the
+     * message for each recipient that would have it in "spam" menu.
+     *
+     * It returns false if the message couldn't be put in the hams folder.
+     */
+    public function markMessageAsHam(Msgs $message): bool
+    {
+        $result = $this->spamassassinService->marksAsHam($message);
+
+        foreach ($message->getMsgRcpts() as $messageRecipient) {
+            if (!$messageRecipient->isSpam()) {
+                continue;
+            }
+
+            $this->restore($messageRecipient);
+        }
+
+        return $result;
     }
 
     /**

--- a/app/src/Service/SpamassassinService.php
+++ b/app/src/Service/SpamassassinService.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\Msgs;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+class SpamassassinService
+{
+    public function __construct(
+        #[Autowire(param: 'app.spamassassin_learn_dir')]
+        private string $spamassassinLearnDir,
+    ) {
+    }
+
+    /**
+     * Put the message content in Spamassassin "spams" folder and return true on success.
+     */
+    public function marksAsSpam(Msgs $message): bool
+    {
+        return $this->putMessage($message, 'spams');
+    }
+
+    /**
+     * Put the message content in Spamassassin "hams" folder and return true on success.
+     */
+    public function marksAsHam(Msgs $message): bool
+    {
+        return $this->putMessage($message, 'hams');
+    }
+
+    /**
+     * @param 'spams'|'hams' $folder
+     */
+    private function putMessage(Msgs $message, string $folder): bool
+    {
+        $outputDirPath = "{$this->spamassassinLearnDir}/{$folder}";
+        if (!is_dir($outputDirPath)) {
+            mkdir($outputDirPath, permissions: 0755, recursive: true);
+        }
+
+        $content = $message->getQuarantineContent();
+
+        $fileName = "{$message->getMailId()}.eml";
+        $filePath = "{$outputDirPath}/{$fileName}";
+
+        return file_put_contents($filePath, $content) !== false;
+    }
+}

--- a/app/templates/message/index.html.twig
+++ b/app/templates/message/index.html.twig
@@ -457,6 +457,37 @@
                                                         {{ 'Message.Actions.Banned'|trans() }}
                                                     </a>
 
+                                                    {% if msgRecipient.isUntreated or msgRecipient.isSpam %}
+                                                        <div class="dropdown-divider"></div>
+
+                                                        {% if msgRecipient.isUntreated %}
+                                                            <a
+                                                                href="{{path('message_mark_as_spam',{
+                                                                    'partitionTag': msgRecipient.partitionTag,
+                                                                    'mailId': msgRecipient.mailIdAsString,
+                                                                    'rid': msgRecipient.rid.id
+                                                                })}}"
+                                                                class="dropdown-item"
+                                                            >
+                                                                <span class="fas fa-thumbs-down"></span>
+                                                                {{ 'Message.Actions.MarkAsSpam' | trans }}
+                                                            </a>
+                                                        {% endif %}
+
+                                                        {% if msgRecipient.isSpam %}
+                                                            <a
+                                                                href="{{path('message_mark_as_ham',{
+                                                                    'partitionTag': msgRecipient.partitionTag,
+                                                                    'mailId': msgRecipient.mailIdAsString,
+                                                                    'rid': msgRecipient.rid.id
+                                                                })}}"
+                                                                class="dropdown-item"
+                                                            >
+                                                                <span class="fas fa-thumbs-up"></span>
+                                                                {{ 'Message.Actions.MarkAsHam' | trans }}
+                                                            </a>
+                                                        {% endif %}
+                                                    {% endif %}
                                                 {% endif %}
                                             </div>
                                         </div>

--- a/app/translations/messages.en.yml
+++ b/app/translations/messages.en.yml
@@ -233,6 +233,8 @@ Message:
     DeleteMessage: "Delete the message"
     Restore: Recover
     RestoreMessage: "Recover the message"
+    MarkAsHam: "Mark as ham"
+    MarkAsSpam: "Mark as spam"
     ipAddressInvalid: "Invalid IP address."
     ipAddressDuplicated: "This IP address is already in the list."
     massiveActionContent:
@@ -282,6 +284,8 @@ Message:
     ruleExists: "This rule already exists!"
     messageDeleted: "Message deleted successfully"
     messageRestored: "Message successfully recovered"
+    messageMarkedAsHam: "Message successfully marked as ham"
+    messageMarkedAsSpam: "Message successfully marked as spam"
     saved: "Changes have been saved."
     messagePendingRelease: "The message will be delivered in a few moments."
     senderAuthorized: "The address is now authorized"

--- a/app/translations/messages.fr.yml
+++ b/app/translations/messages.fr.yml
@@ -233,6 +233,8 @@ Message:
     DeleteMessage: Supprimer le message
     Restore: Récupérer
     RestoreMessage: Récupérer le message
+    MarkAsHam: Marquer comme acceptable
+    MarkAsSpam: Marquer comme spam
     ipAddressInvalid: Le format l'adresse IP est incorrect.
     ipAddressDuplicated: l'adresse IP est en double.
     massiveActionContent:
@@ -282,6 +284,8 @@ Message:
     ruleExists: Cette règle existe déjà !
     messageDeleted: Message supprimé avec succès
     messageRestored: Message récupéré avec succès
+    messageMarkedAsHam: Message marqué comme acceptable avec succès
+    messageMarkedAsSpam: Message marqué comme spam avec succès
     saved: Les changements ont été enregistrés.
     messagePendingRelease: Le message va être délivré dans quelques instants.
     senderAuthorized: L'adresse est désormais autorisée

--- a/docs/developers/bayes_filtering.md
+++ b/docs/developers/bayes_filtering.md
@@ -9,11 +9,15 @@ In development, the folder `sa_learn/` at the root of the project is used so you
 This folder contains two subfolders: `hams/` and `spams/`.
 Each hour, a script in the `amavis` container reads the mails present in these both folders to learn what is a spam and what is a ham.
 
-Mails can be put in this folder either manually, or using the dedicated Symfony command:
+Mails can be marked as spam/ham with different methods:
 
-```console
-$ ./scripts/console agentj:messages:mark-as spam [MAIL ID]
-$ ./scripts/console agentj:messages:mark-as ham [MAIL ID]
-```
+1. The recommended method is to use the web interface as an admin to mark the mails;
+2. Alternatively, a console command can be used:
+    ```console
+    $ ./scripts/console agentj:messages:mark-as spam [MAIL ID]
+    $ ./scripts/console agentj:messages:mark-as ham [MAIL ID]
+    ```
+3. To setup the system the first time, you may want to put spams and hams in the folders manually.
 
-This command also marks the mail as spam in the interface, or release it in case of ham.
+When marking a mail as spam using methods 1 and 2, it also moves any untreated mail to spams.
+In case of marking a spam as ham using methods 1 and 2, the mail is automatically released.


### PR DESCRIPTION
## Related issue(s)
<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

Follow up of #427 

## How to test manually
<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Login as an admin
2. Go to the untreated messages
3. Mark a mail as spam
4. Verify it is moved to spams and that a file is created under `sa_learn/spams`
2. Go to the spam messages
3. Mark a mail as ham
4. Verify it is released and that a file is created under `sa_learn/hams`

## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works on both Firefox and Chrome
- [x] Tests are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
