### PR TITLE
fix: clear cache before running sf command

### DIFF
--- a/app/docker/entrypoint.sh
+++ b/app/docker/entrypoint.sh
@@ -6,6 +6,7 @@ sh /setup-env.sh
 sed -i 's|memory_limit = 128M|memory_limit = 512M|g' /etc/php/8.2/cli/php.ini
 
 cd /var/www/agentj || exit 4
+rm -rf /var/www/agentj/var/cache
 
 if [ -x "$(which composer)" ] && [ -x "$(which yarnpkg)" ] ; then
 	echo "Installing libraries"
@@ -27,7 +28,6 @@ echo "update groups wblist"
 sudo -u www-data php bin/console agentj:update-groups-wblist
 
 # Allow web server user to write Symphony logs
-rm -rf /var/www/agentj/var/cache
 chown -R www-data:www-data /var/www/agentj/var
 find /var/www/agentj/public -type d -exec chmod go+rwx {} \;
 


### PR DESCRIPTION
## Related issue(s)
https://github.com/Probesys/agentj/issues/434

## How to test manually
- Stop and clean instance `make docker-clean`
- Setup SF_APP_ENV to "prod"
- Swicth to tag 2.5.2
- Start the stack until is up.
- Stop the stack `docker compose down`
- switch to branch fix/cache-clear-entrypoint
- Restart the stack and ensure the service app is up

## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works on both Firefox and Chrome
- [x] Tests are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
