### PR TITLE
fix: show bottom of dropdown actions in messages

### DIFF
--- a/app/templates/message/index.html.twig
+++ b/app/templates/message/index.html.twig
@@ -218,7 +218,7 @@
                                         </div>
                                     {% else %}
                                         <div class="dropdown">
-                                            <button class="btn btn-primary dropdown-toggle" type="button" data-toggle="dropdown">
+                                            <button class="btn btn-primary dropdown-toggle" type="button" data-toggle="dropdown" data-boundary="viewport">
                                                 Action
                                             </button>
                                             <div class="dropdown-menu" style="z-index:10300">


### PR DESCRIPTION
## Related issue(s)
N/A

## How to test manually
- Ensure to have only one mail in untreated messages
- Verify that all the dropdown is visible

## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works on both Firefox and Chrome
- [x] Tests are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
