### PR TITLE
fix: Authorize senders by the envelope address

### DIFF
--- a/app/src/Entity/BaseMessage.php
+++ b/app/src/Entity/BaseMessage.php
@@ -334,32 +334,12 @@ class BaseMessage
     }
 
     /**
-     * Return either the envelope sender address, or the "From" header address
-     * if it exists.
-     *
-     * This method is used to get the address to authorize or ban. However,
-     * please note that Amavis looks exclusively the envelope sender address
-     * when allowing/blocking an email. Said otherwise, if both envelope
-     * address and "From" address are different, the future emails sent with
-     * the envelop address will not be automatically allowed (nor blocked). It
-     * is a known drawback of the authorizing/banning mechanism.
-     *
-     * Luckily, it is still possible to authorize/ban an email again manually.
-     *
-     * A better idea may be to authorize/ban both addresses though.
+     * Return the envelope sender email address.
      */
     public function getSenderEmail(): ?string
     {
         $sender = $this->getSid();
-
-        $senderEmail = $sender->getEmailClear();
-        $fromEmail = $this->getFromMimeAddress()?->getAddress();
-
-        if ($fromEmail && $senderEmail !== $fromEmail) {
-            return $fromEmail;
-        } else {
-            return $senderEmail;
-        }
+        return $sender->getEmailClear();
     }
 
     public function getStatus(): ?int


### PR DESCRIPTION
## Related issue(s)
<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

https://github.com/Probesys/agentj/issues/437

We release emails by considering the envelope address (in the maddr table, referenced by msgs.sid). It means that when we authorize/ban a user, we must use the same address. Until now, we used the address of the "From" header.

## How to test manually
<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Change the script `./scripts/mail_to_agentj.sh` by adding a From header (`--h-From "test@smtp.test"`)
2. Send an email with `./scripts/mail_to_agentj.sh`
3. In the interface, authorize the sender
4. Verify in the list of authorized users that `root@smtp.test` is authorized

## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works on both Firefox and Chrome
- [x] Tests are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
