### PR TITLE
fix: Consider original user when checking for "bypass human auth" option

### DIFF
--- a/app/src/Command/AmavisAutoReleaseCommand.php
+++ b/app/src/Command/AmavisAutoReleaseCommand.php
@@ -58,6 +58,12 @@ class AmavisAutoReleaseCommand extends Command
             $sender = $messageRecipient->getMsgs()->getSid();
 
             $recipientUser = $this->userRepository->findOneByMailAddress($recipient);
+
+            $recipientOriginalUser = $recipientUser->getOriginalUser();
+            if ($recipientOriginalUser) {
+                $recipientUser = $recipientOriginalUser;
+            }
+
             $recipientDomain = $recipientUser->getDomain();
 
             $senderIsAuthorized = $this->wblistRepository->isSenderAuthorizedByRecipient($sender, $recipient);


### PR DESCRIPTION
## Related issue(s)
<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

https://github.com/Probesys/agentj/issues/457

## How to test manually
<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Create an alias of the user `user@blocnormal.fr`
2. Connect as `user@blocnormal.fr` and disable the human authentication
3. Send an email with `./scripts/mail_to_agentj.sh` and verify that the email is delivered
4. Change the script to send the mail to the new alias, and send another mail
5. Verify that the email is also delivered

## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works on both Firefox and Chrome
- [x] Tests are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
