### PR TITLE
fix: Authorize senders by the From address

### DIFF
--- a/app/src/Command/AmavisAutoReleaseCommand.php
+++ b/app/src/Command/AmavisAutoReleaseCommand.php
@@ -55,7 +55,7 @@ class AmavisAutoReleaseCommand extends Command
 
         foreach ($messageRecipients as $messageRecipient) {
             $recipient = $messageRecipient->getRid();
-            $sender = $messageRecipient->getMsgs()->getSid();
+            $senderEmail = $messageRecipient->getMsgs()->getSenderEmail();
 
             $recipientUser = $this->userRepository->findOneByMailAddress($recipient);
 
@@ -66,7 +66,7 @@ class AmavisAutoReleaseCommand extends Command
 
             $recipientDomain = $recipientUser->getDomain();
 
-            $senderIsAuthorized = $this->wblistRepository->isSenderAuthorizedByRecipient($sender, $recipient);
+            $senderIsAuthorized = $this->wblistRepository->isSenderAuthorizedByRecipient($senderEmail, $recipient);
             $humanAuthIsDisabled = $recipientUser->getBypassHumanAuth();
 
             $spamLevel = $recipientDomain->getLevel();

--- a/app/src/Controller/HumanAuthenticationsController.php
+++ b/app/src/Controller/HumanAuthenticationsController.php
@@ -38,8 +38,7 @@ class HumanAuthenticationsController extends AbstractController
             throw $this->createNotFoundException('The domain does not exist.');
         }
 
-        $sender = $message->getSid();
-        $senderEmail = $sender->getEmailClear();
+        $senderEmail = $message->getSenderEmail();
 
         $form = $this->createForm(HumanAuthenticationType::class, [
             'email' => $senderEmail,
@@ -59,12 +58,12 @@ class HumanAuthenticationsController extends AbstractController
                 empty($form->get('emailEmpty')->getData())
             ) {
                 // Keep only recipients that are NOT already in a wblist. This avoids,
-                // for a instance, a blocked sender to authorise himself.
+                // for instance, a blocked sender to authorise himself.
                 $messageRecipients = array_filter(
                     $messageRecipients,
-                    function ($messageRecipient) use ($wblistRepository, $sender) {
+                    function ($messageRecipient) use ($wblistRepository, $senderEmail) {
                         $recipient = $messageRecipient->getRid();
-                        return !$wblistRepository->isSenderInRecipientList($sender, $recipient);
+                        return !$wblistRepository->isSenderInRecipientList($senderEmail, $recipient);
                     }
                 );
 

--- a/app/src/Controller/MessageController.php
+++ b/app/src/Controller/MessageController.php
@@ -246,8 +246,8 @@ class MessageController extends AbstractController
             'mailId' => $mailId,
         ]);
 
-        $wblists = $this->em->getRepository(Wblist::class)->findByMailAddresses(
-            $msg->getSid(),
+        $wblists = $this->em->getRepository(Wblist::class)->findBySenderEmailAndRecipient(
+            $msg->getSenderEmail(),
             $msgRcpt->getRid(),
         );
 

--- a/app/src/Entity/BaseMessage.php
+++ b/app/src/Entity/BaseMessage.php
@@ -334,12 +334,29 @@ class BaseMessage
     }
 
     /**
-     * Return the envelope sender email address.
+     * Return the email value from the "From" header address, or the envelope
+     * sender address as fallback if From is not set.
+     *
+     * This method is used to get the address email to authorize or ban.
+     *
+     * It considers the "From" header in priority because the envelope sender
+     * address can change for a same sender. For instance, a newsletter will
+     * always be sent using the same "From", but some services will use a
+     * unique and random envelope address for each delivery. Thus, we must rely
+     * on the stable "From" value.
      */
     public function getSenderEmail(): ?string
     {
         $sender = $this->getSid();
-        return $sender->getEmailClear();
+        $senderEmail = $sender->getEmailClear();
+
+        $fromEmail = $this->getFromMimeAddress()?->getAddress();
+
+        if ($fromEmail) {
+            return $fromEmail;
+        } else {
+            return $senderEmail;
+        }
     }
 
     public function getStatus(): ?int

--- a/app/src/Repository/MsgrcptRepository.php
+++ b/app/src/Repository/MsgrcptRepository.php
@@ -45,44 +45,61 @@ class MsgrcptRepository extends BaseRepository
     }
 
     /**
-     * Return all message recipients sent by $senderEmail to $recipientUser.
+     * Return all message recipients sent by $senderFrom to $recipientUser.
+     *
+     * This method is used to fetch the messages sent by a sender who just had
+     * been authorized or banned by a user. It fetches the messages by using
+     * the raw "From" value. We cannot pass the "senderEmail" value because it
+     * is either the email part of the From value, or the envelope sender
+     * address if From is empty. In other words, this value cannot be used to
+     * fetch the mails, and the envelope sender address is not reliable as it
+     * can be some random emails (e.g. mails sent by newsletter operators).
+     *
+     * It is highly recommended to recheck the senderEmail on the messages
+     * returned by this method in order to be sure to release or ban the
+     * correct messages.
      *
      * @return Msgrcpt[]
      */
-    public function findSentToUserByEmail(User $recipientUser, string $senderEmail): array
+    public function findSentToUserByEmail(User $recipientUser, string $senderFrom): array
     {
         $query = $this->getEntityManager()->createQuery(<<<SQL
             SELECT mrcpt
             FROM App\Entity\Msgrcpt mrcpt
             JOIN mrcpt.msgs m
-            JOIN m.sid s
             JOIN mrcpt.rid r
             WHERE r.email = :recipientEmail
-            AND s.email = :senderEmail
+            AND m.fromAddr = :senderFrom
             AND mrcpt.status IS NOT NULL
         SQL);
 
         $query->setParameter('recipientEmail', $recipientUser->getEmail());
-        $query->setParameter('senderEmail', $senderEmail);
+        $query->setParameter('senderFrom', $senderFrom);
 
         return $query->getResult();
     }
 
     /**
-     * Return all message recipients sent by $senderEmail to $recipientDomain.
+     * Return all message recipients sent by $senderFrom to $recipientDomain.
+     *
+     * As for findSentToUserByEmail, this method fetches the messages by using
+     * the raw "From" value. See above for the reasons.
+     *
+     * It is highly recommended to recheck the senderEmail on the messages
+     * returned by this method in order to be sure to release or ban the
+     * correct messages.
      *
      * @return Msgrcpt[]
      */
-    public function findSentToDomainByEmail(Domain $recipientDomain, string $senderEmail): array
+    public function findSentToDomainByEmail(Domain $recipientDomain, string $senderFrom): array
     {
         $query = $this->getEntityManager()->createQuery(<<<SQL
             SELECT mrcpt
             FROM App\Entity\Msgrcpt mrcpt
             JOIN mrcpt.msgs m
-            JOIN m.sid s
             JOIN mrcpt.rid r
             WHERE r.domain = :recipientReverseDomainName
-            AND s.email = :senderEmail
+            AND m.fromAddr = :senderFrom
             AND mrcpt.status IS NOT NULL
         SQL);
 
@@ -90,7 +107,7 @@ class MsgrcptRepository extends BaseRepository
         $reverseDomainName = Url::reverseDomainName($domainName);
 
         $query->setParameter('recipientReverseDomainName', $reverseDomainName);
-        $query->setParameter('senderEmail', $senderEmail);
+        $query->setParameter('senderFrom', $senderFrom);
 
         return $query->getResult();
     }

--- a/app/src/Repository/WblistRepository.php
+++ b/app/src/Repository/WblistRepository.php
@@ -159,10 +159,10 @@ class WblistRepository extends BaseRepository
      *
      * @return Wblist[]
      */
-    public function findByMailAddresses(Maddr $sender, Maddr $recipient): array
+    public function findBySenderEmailAndRecipient(string $senderEmail, Maddr $recipient): array
     {
         $recipientAddresses = Email::getAddressLookups($recipient->getEmailClear());
-        $senderAddresses = Email::getAddressLookups($sender->getEmailClear());
+        $senderAddresses = Email::getAddressLookups($senderEmail);
 
         $entityManager = $this->getEntityManager();
         $connection = $entityManager->getConnection();
@@ -206,9 +206,9 @@ class WblistRepository extends BaseRepository
         return $wblists;
     }
 
-    public function isSenderAuthorizedByRecipient(Maddr $sender, Maddr $recipient): bool
+    public function isSenderAuthorizedByRecipient(string $senderEmail, Maddr $recipient): bool
     {
-        $wblists = $this->findByMailAddresses($sender, $recipient);
+        $wblists = $this->findBySenderEmailAndRecipient($senderEmail, $recipient);
 
         if (count($wblists) === 0) {
             return false;
@@ -217,9 +217,9 @@ class WblistRepository extends BaseRepository
         return $wblists[0]->isWbRuleAuthorized();
     }
 
-    public function isSenderInRecipientList(Maddr $sender, Maddr $recipient): bool
+    public function isSenderInRecipientList(string $senderEmail, Maddr $recipient): bool
     {
-        $wblists = $this->findByMailAddresses($sender, $recipient);
+        $wblists = $this->findBySenderEmailAndRecipient($senderEmail, $recipient);
 
         if (count($wblists) === 0) {
             return false;

--- a/app/src/Service/MessageService.php
+++ b/app/src/Service/MessageService.php
@@ -68,9 +68,13 @@ class MessageService
                 $message->getFromAddr()
             );
 
+            $domain = $user->getDomain();
+            $domainSpamLevel = $domain->getAuthorizedSendersSpamLevel();
+
             foreach ($messageRecipientsToRelease as $messageRecipientToRelease) {
                 $isSameSender = $messageRecipientToRelease->getMsgs()->getSenderEmail() === $senderEmail;
-                if (!$isSameSender) {
+                $isSpam = $messageRecipientToRelease->isSpamAtLevel($domainSpamLevel);
+                if (!$isSameSender || $isSpam) {
                     continue;
                 }
 
@@ -104,6 +108,8 @@ class MessageService
         $recipientDomainName = $recipient->getReverseDomain();
 
         $domainUser = $this->userRepository->findDomainUser($recipientDomainName);
+        $domain = $domainUser->getDomain();
+        $domainSpamLevel = $domain->getAuthorizedSendersSpamLevel();
 
         $this->wblistRepository->updateOrCreateRule(
             $domainUser,
@@ -114,13 +120,14 @@ class MessageService
         );
 
         $messageRecipientsToRelease = $this->messageRecipientRepository->findSentToDomainByEmail(
-            $domainUser->getDomain(),
+            $domain,
             $message->getFromAddr(),
         );
 
         foreach ($messageRecipientsToRelease as $messageRecipientToRelease) {
             $isSameSender = $messageRecipientToRelease->getMsgs()->getSenderEmail() === $senderEmail;
-            if (!$isSameSender) {
+            $isSpam = $messageRecipientToRelease->isSpamAtLevel($domainSpamLevel);
+            if (!$isSameSender || $isSpam) {
                 continue;
             }
 

--- a/app/src/Service/MessageService.php
+++ b/app/src/Service/MessageService.php
@@ -63,9 +63,17 @@ class MessageService
                 priority: Wblist::WBLIST_PRIORITY_USER,
             );
 
-            $messageRecipientsToRelease = $this->messageRecipientRepository->findSentToUserByEmail($user, $senderEmail);
+            $messageRecipientsToRelease = $this->messageRecipientRepository->findSentToUserByEmail(
+                $user,
+                $message->getFromAddr()
+            );
 
             foreach ($messageRecipientsToRelease as $messageRecipientToRelease) {
+                $isSameSender = $messageRecipientToRelease->getMsgs()->getSenderEmail() === $senderEmail;
+                if (!$isSameSender) {
+                    continue;
+                }
+
                 $this->dispatchRelease($messageRecipientToRelease, MessageStatus::AUTHORIZED);
             }
         }
@@ -107,10 +115,15 @@ class MessageService
 
         $messageRecipientsToRelease = $this->messageRecipientRepository->findSentToDomainByEmail(
             $domainUser->getDomain(),
-            $senderEmail,
+            $message->getFromAddr(),
         );
 
         foreach ($messageRecipientsToRelease as $messageRecipientToRelease) {
+            $isSameSender = $messageRecipientToRelease->getMsgs()->getSenderEmail() === $senderEmail;
+            if (!$isSameSender) {
+                continue;
+            }
+
             $this->dispatchRelease($messageRecipientToRelease, MessageStatus::AUTHORIZED);
         }
 
@@ -148,10 +161,18 @@ class MessageService
                 priority: Wblist::WBLIST_PRIORITY_USER,
             );
 
-            $messageRecipientsToBan = $this->messageRecipientRepository->findSentToUserByEmail($user, $senderEmail);
+            $messageRecipientsToBan = $this->messageRecipientRepository->findSentToUserByEmail(
+                $user,
+                $message->getFromAddr()
+            );
 
             foreach ($messageRecipientsToBan as $messageRecipientToBan) {
-                if ($messageRecipientToBan->isVirus() || $messageRecipientToBan->isAlreadyReleased()) {
+                $isSameSender = $messageRecipientToBan->getMsgs()->getSenderEmail() === $senderEmail;
+                if (
+                    !$isSameSender ||
+                    $messageRecipientToBan->isVirus() ||
+                    $messageRecipientToBan->isAlreadyReleased()
+                ) {
                     continue;
                 }
 
@@ -197,11 +218,16 @@ class MessageService
 
         $messageRecipientsToBan = $this->messageRecipientRepository->findSentToDomainByEmail(
             $domainUser->getDomain(),
-            $senderEmail,
+            $message->getFromAddr(),
         );
 
         foreach ($messageRecipientsToBan as $messageRecipientToBan) {
-            if ($messageRecipientToBan->isVirus() || $messageRecipientToBan->isAlreadyReleased()) {
+            $isSameSender = $messageRecipientToBan->getMsgs()->getSenderEmail() === $senderEmail;
+            if (
+                !$isSameSender ||
+                $messageRecipientToBan->isVirus() ||
+                $messageRecipientToBan->isAlreadyReleased()
+            ) {
                 continue;
             }
 


### PR DESCRIPTION
## Related issue(s)
<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

https://github.com/Probesys/agentj/issues/456

## How to test manually
<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Change the script `./scripts/mail_to_agentj.sh` by adding a From header (`--h-From "test@smtp.test"`)
2. Send an email with `./scripts/mail_to_agentj.sh`
3. In the interface, authorize the sender
4. Verify in the list of authorized users that `test@smtp.test` is authorized

## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works on both Firefox and Chrome
- [x] Tests are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
