### PR TITLE
fix: add default values to user report and bypass_human_auth

### DIFF
--- a/app/migrations/Version20260521141800.php
+++ b/app/migrations/Version20260521141800.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260521141800 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Set default values to report and bypass_human_auth in users table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('UPDATE users SET report=false WHERE report IS NULL');
+        $this->addSql('UPDATE users SET bypass_human_auth=false WHERE bypass_human_auth IS NULL');
+        $this->addSql(<<<SQL
+            ALTER TABLE users
+            CHANGE report report TINYINT(1) DEFAULT 1 NOT NULL,
+            CHANGE bypass_human_auth bypass_human_auth TINYINT(1) DEFAULT 0 NOT NULL;
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql(<<<SQL
+            ALTER TABLE users
+            CHANGE report report TINYINT(1) DEFAULT NULL,
+            CHANGE bypass_human_auth bypass_human_auth TINYINT(1) DEFAULT NULL
+        SQL);
+    }
+}

--- a/app/src/Entity/User.php
+++ b/app/src/Entity/User.php
@@ -92,8 +92,8 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     #[ORM\OneToMany(targetEntity: User::class, mappedBy: 'originalUser')]
     private Collection $aliases;
 
-    #[ORM\Column(type: 'boolean', nullable: true)]
-    private ?bool $report;
+    #[ORM\Column(type: 'boolean', nullable: false, options: ['default' => true])]
+    private bool $report = true;
 
     /**
      * @var Collection<int, User>
@@ -110,8 +110,8 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     #[ORM\Column(type: 'integer', nullable: true)]
     private ?int $dateLastReport;
 
-    #[ORM\Column(type: 'boolean', nullable: true)]
-    private ?bool $bypassHumanAuth;
+    #[ORM\Column(type: 'boolean', nullable: false, options: ['default' => false])]
+    private bool $bypassHumanAuth = false;
 
     #[ORM\Column(type: 'string', length: 5, nullable: true)]
     private ?string $preferedLang;


### PR DESCRIPTION
Issue: #455

## Related issue(s)
github.com/Probesys/agentj/issues/455

## How to test manually

1. Check in the database that the columns are null ./scripts/mariadb agentj -e "SELECT report, bypass_human_auth FROM users;"
2. Apply migration : `make db-migrate`
3. Check in the database that there is no null values in the columns `./scripts/mariadb agentj -e "SELECT report, bypass_human_auth FROM users;"`
4. Create a user in the interface, or import users with a LDAP connector
5. Check in the database that the columns have correct default values `./scripts/mariadb agentj -e "SELECT report, bypass_human_auth FROM users WHERE email='[EMAIL]';"`


## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works on both Firefox and Chrome
- [x] Tests are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved