### PR TITLE
chore: Fix permissions on sa_learn docker volume

### DIFF
--- a/app/docker/entrypoint.sh
+++ b/app/docker/entrypoint.sh
@@ -29,6 +29,10 @@ sudo -u www-data php bin/console agentj:update-groups-wblist
 
 # Allow web server user to write Symphony logs
 chown -R www-data:www-data /var/www/agentj/var
+
+# Allow web server user to write Spamassassin learn data
+chown -R www-data:www-data /var/www/agentj/sa_learn
+
 find /var/www/agentj/public -type d -exec chmod go+rwx {} \;
 
 echo "Installing crontabs"


### PR DESCRIPTION
## Related issue(s)
https://github.com/Probesys/agentj/issues/454

## How to test manually
- [x] Modifiy compose.dev.yml to change volume sa_learn `- sa_learn:/var/www/agentj/sa_learn`
- [x] Run `make docker-start`
- [x] Send an email
- [x] Mark a mail as spam : you should not have error



## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works on both Firefox and Chrome
- [x] Tests are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
