### PR TITLE
fix: add missing indexes on messenger_messages table

### DIFF
--- a/app/migrations/Version20260526130125.php
+++ b/app/migrations/Version20260526130125.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260526130125 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add missing indexes in messenger_messages table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX IDX_75EA56E016BA31DB ON messenger_messages');
+        $this->addSql('DROP INDEX IDX_75EA56E0FB7336F0 ON messenger_messages');
+        $this->addSql('DROP INDEX IDX_75EA56E0E3BD61CE ON messenger_messages');
+        $this->addSql(<<<'SQL'
+            CREATE INDEX IDX_75EA56E0FB7336F0E3BD61CE16BA31DBBF396750
+            ON messenger_messages (queue_name, available_at, delivered_at, id)
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX IDX_75EA56E0FB7336F0E3BD61CE16BA31DBBF396750 ON messenger_messages');
+        $this->addSql('CREATE INDEX IDX_75EA56E016BA31DB ON messenger_messages (delivered_at)');
+        $this->addSql('CREATE INDEX IDX_75EA56E0FB7336F0 ON messenger_messages (queue_name)');
+        $this->addSql('CREATE INDEX IDX_75EA56E0E3BD61CE ON messenger_messages (available_at)');
+    }
+}


### PR DESCRIPTION
Issue: #471

## Related issue(s)
<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

## How to test manually
<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->
- make db-migrate
- assume migration is applied, and indexes are created (`show indexes from messenger_messages;`)

## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [ ] Code is manually tested
- [ ] Interface works on both mobiles and big screens
- [ ] Interface works on both Firefox and Chrome
- [ ] Tests are up to date
- [ ] Documentation is up to date
- [ ] Pull request has been reviewed and approved
