### PR TITLE
fix(ldap): Don't assign groups to non-synchronized users

### DIFF
--- a/app/src/Command/LDAPImportCommand.php
+++ b/app/src/Command/LDAPImportCommand.php
@@ -82,7 +82,7 @@ class LDAPImportCommand extends Command
             $this->importGroups();
         }
 
-        $this->assignGroupsToImportedUsers();
+        $this->groupService->updateWblist();
 
         return Command::SUCCESS;
     }
@@ -148,6 +148,8 @@ class LDAPImportCommand extends Command
                         }
                     }
                 }
+
+                $this->assignTargetGroupsToUser($user);
             }
         }
 
@@ -262,7 +264,7 @@ class LDAPImportCommand extends Command
         $this->em->flush();
     }
 
-    private function assignGroupsToImportedUsers(): void
+    private function assignTargetGroupsToUser(User $user): void
     {
         $targetGroups = $this->connector->getTargetGroups();
 
@@ -270,14 +272,11 @@ class LDAPImportCommand extends Command
             return;
         }
 
-        foreach ($this->connector->getUsers() as $user) {
-            foreach ($targetGroups as $group) {
-                $user->addGroup($group);
-            }
-
-            $this->userService->updateAliasGroupsAndPolicyFromUser($user);
+        foreach ($targetGroups as $group) {
+            $user->addGroup($group);
         }
-        $this->groupService->updateWblist();
+
+        $this->userService->updateAliasGroupsAndPolicyFromUser($user);
     }
 
     private function importGroups(): void


### PR DESCRIPTION
## Related issue(s)
<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

A user that has been synchronized by a connector is always attached to it, even if LDAP no longer returns this user.

This causes an issue when assigning target groups because we were assigning them using `$connector->getUsers()` which returns all the users that have been imported by the connector in the past.

Now, the target groups are only assigned to the users fetched from LDAP during the synchronization.

## How to test manually
<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Setup a LDAP connector as described in the documentation, make sure to assign users to a group
2. Import the users and verify that they are assigned to the group you specified
3. Remove the group from a user, e.g. "alix@example.com"
4. Change "Filter for users" of the connector, e.g. `(cn=charlie)`
5. Import the users again
6. Verify that the user (e.g. alix@example.com) is still not assigned to the group

## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works on both Firefox and Chrome
- [x] Tests are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
