### PR TITLE
fix: Bring user menu back on mobile

### DIFF
--- a/app/templates/header.html.twig
+++ b/app/templates/header.html.twig
@@ -38,6 +38,9 @@
                 <a data-turbo="false" class="nav-link dropdown-toggle font-weight-bolder d-none d-md-block" href="#" id="userDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                     {{app.user.username}}
                 </a>
+                <a data-turbo="false" class="nav-link dropdown-toggle font-weight-bolder d-block d-md-none" href="#" id="userDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                    @
+                </a>
 
                 <div class="dropdown-menu dropdown-menu-right " aria-labelledby="userDropdown">
                     {% if not is_granted('ROLE_ADMIN') %}


### PR DESCRIPTION
## Related issue(s)
<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

On mobile, the user menu disappeared (since bcd82d58).

## How to test manually
<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. open AgentJ in mobile mode (ctrl+maj+M)
2. verify that on small screens, the user menu appears as "@"  entry

## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works on both Firefox and Chrome
- [x] Tests are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
