### PR TITLE
chore: Allow Nginx app to be set behind a reverse proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,10 +57,14 @@ ENABLE_AZURE_OAUTH=false
 OAUTH_AZURE_CLIENT_SECRET=changeme
 OAUTH_AZURE_CLIENT_ID=changeme
 
-# Host IP to expose app web interface
+# Host IP to expose the Docker app container
 PROXY_LISTEN_ADDR=127.0.0.1
-# Host port to expose app web interface
+# Host port to expose the Docker app container
 PROXY_PORT=8090
+# Host port that exposes the app's web interface to the outside world. It
+# defaults to the PROXY_PORT value. This must only be set if a reverse proxy
+# has been set up in front of the Docker app container.
+#FRONT_PORT=8000
 # symfony trusted_proxies
 # see https://symfony.com/doc/current/deployment/proxies.html
 TRUSTED_PROXIES=

--- a/app/docker/entrypoint.sh
+++ b/app/docker/entrypoint.sh
@@ -3,10 +3,11 @@ set -e
 
 sh /setup-env.sh
 
-if [ "$PROXY_PORT" -eq 80 ] || [ "$PROXY_PORT" -eq 443 ]; then
+FRONT_PORT="${FRONT_PORT:-$PROXY_PORT}"
+if [ "$FRONT_PORT" -eq 80 ] || [ "$FRONT_PORT" -eq 443 ]; then
     sed -i "s|\$HTTP_HOST_PORT||g" /etc/nginx/sites-enabled/default
 else
-    sed -i "s|\$HTTP_HOST_PORT|:${PROXY_PORT}|g" /etc/nginx/sites-enabled/default
+    sed -i "s|\$HTTP_HOST_PORT|:${FRONT_PORT}|g" /etc/nginx/sites-enabled/default
 fi
 
 sed -i 's|memory_limit = 128M|memory_limit = 512M|g' /etc/php/8.2/cli/php.ini


### PR DESCRIPTION
## Related issue(s)
<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

N/A

## How to test manually
<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Rebuild the images with `make docker-images` and restart the stack
2. Check that the app is running at http://localhost:8090
3. Check that the Nginx HTTP host is set with the proxy port: `docker compose exec app cat /etc/nginx/sites-enabled/default | grep HTTP_HOST` (should be `$host:8090`) → when you login, you should be redirected to localhost:8090
4. Set the `FRONT_PORT` in your .env (e.g 8000) and restart the stack
5. Check that the app is still running at http://localhost:8090
6. Check that the Nginx HTTP host is set with the front port: `docker compose exec app cat /etc/nginx/sites-enabled/default | grep HTTP_HOST` (should be `$host:8000`) → when you login, you should be redirected to localhost:8000 (it fails but its expected as you probably don't have a reverse proxy listening at port 8000)

## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works on both Firefox and Chrome
- [x] Tests are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
