### PR TITLE
fix: Fix accessing groups for super admin

### DIFF
--- a/app/src/Controller/GroupsController.php
+++ b/app/src/Controller/GroupsController.php
@@ -11,6 +11,7 @@ use App\Form\GroupsType;
 use App\Service\GroupService;
 use App\Service\UserService;
 use App\Repository\UserRepository;
+use App\Repository\GroupsRepository;
 use App\Repository\GroupsWblistRepository;
 use App\Repository\MailaddrRepository;
 use Doctrine\ORM\EntityManagerInterface;
@@ -27,8 +28,11 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 #[Route(path: '/groups')]
 class GroupsController extends AbstractController
 {
-    public function __construct(private EntityManagerInterface $em, private TranslatorInterface $translator)
-    {
+    public function __construct(
+        private EntityManagerInterface $em,
+        private GroupsRepository $groupsRepository,
+        private TranslatorInterface $translator,
+    ) {
     }
 
     private function checkAccess(Groups $group): void
@@ -45,9 +49,13 @@ class GroupsController extends AbstractController
     {
         /** @var User $user */
         $user = $this->getUser();
-        $groups = $this->em
-                ->getRepository(Groups::class)
-                ->findByDomains($user->getDomains()->toArray());
+
+        if ($this->isGranted('ROLE_SUPER_ADMIN')) {
+            $groups = $this->groupsRepository->findAll();
+        } else {
+            $userDomains = $user->getDomains()->toArray();
+            $groups = $this->groupsRepository->findByDomains($userDomains);
+        }
 
         return $this->render('groups/index.html.twig', ['groups' => $groups]);
     }

--- a/app/src/Repository/GroupsRepository.php
+++ b/app/src/Repository/GroupsRepository.php
@@ -42,12 +42,13 @@ class GroupsRepository extends BaseRepository
      */
     public function findByDomains(array $domains): array
     {
-        $dql = $this->createQueryBuilder('g');
-
-        if ($domains) {
-            $dql->where('g.domain in (:domains)');
-            $dql->setParameter('domains', $domains);
+        if (count($domains) === 0) {
+            return [];
         }
+
+        $dql = $this->createQueryBuilder('g');
+        $dql->where('g.domain in (:domains)');
+        $dql->setParameter('domains', $domains);
 
         return $dql->getQuery()->getResult();
     }


### PR DESCRIPTION
## Related issue(s)
<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

The super-admin has access to all the domains and, thus, is not attached to any particular domain. However, when updating the super-admin, he's attached to all the domains. It means that when we create a domain after editing the super-admin, he's attached to a subset of the domains.

It is not an issue in general, but in the case of listing the groups, it created an issue where the super-admin wasn't able to see the groups attached to the new domain.

The case is now handled by considering the super-admin role rather than the domains he's attached to.

## How to test manually
<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Update the super admin (just submit the edit form)
2. Create a domain
3. Attach an existing group to this new domain
4. Verify that you still can see the group

## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works on both Firefox and Chrome
- [x] Tests are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
