### PR TITLE
Fix: enforce safe permissions on the app cron.d file

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -84,7 +84,7 @@ RUN rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /var/run/php/ && touch /var/run/php/php84-fpm.pid
 RUN rm -rf node_modules
 
-COPY docker/conf/cron/agentj /etc/cron.d/agentj
+COPY --chmod=644 docker/conf/cron/agentj /etc/cron.d/agentj
 COPY docker/conf/nginx/nginx.conf /etc/nginx/sites-enabled/default
 COPY docker/conf/php-fpm/www.conf /etc/php/8.4/fpm/pool.d/www.conf
 COPY docker/conf/supervisor/supervisord.conf /etc/supervisord.conf

--- a/app/Dockerfile.dev
+++ b/app/Dockerfile.dev
@@ -50,7 +50,7 @@ RUN mkdir -p /var/run/php/ && touch /var/run/php/php84-fpm.pid
 
 
 COPY docker/files/docker-php-ext-xdebug.ini /etc/php/8.4/fpm/conf.d/docker-php-ext-xdebug.ini
-COPY docker/conf/cron/agentj /etc/cron.d/agentj
+COPY --chmod=644 docker/conf/cron/agentj /etc/cron.d/agentj
 COPY docker/conf/nginx/nginx.conf /etc/nginx/sites-enabled/default
 COPY docker/conf/php-fpm/www.conf /etc/php/8.4/fpm/pool.d/www.conf
 COPY docker/conf/supervisor/supervisord.conf /etc/supervisord.conf


### PR DESCRIPTION
## Summary

`app/Dockerfile` does `COPY docker/conf/cron/agentj /etc/cron.d/agentj` without ever forcing the file's permissions afterward. `COPY` preserves whatever mode the file has in the build context, which depends on the umask of the machine that built the image — the file is correctly tracked as `100644` in git, but if the build environment's umask is permissive (e.g. `002` instead of `022`), the file ends up `664` (group-writable) in the resulting image.

Debian's `cron` silently refuses to load a crontab file in `/etc/cron.d` that is writable by group or other — with **no error surfaced anywhere** (no log, no mail, nothing). The practical effect: every AgentJ scheduled task defined in that file (`agentj:send-auth-mail-token`, `app:create-alert-for-user`, `app:create-alert-for-admin`, `agentj:report-send-mail`, `agent:save-stat`) silently never runs, even though `crontab`/`/etc/cron.d` listing looks completely normal and the file's content is correct.

## How this was found

While debugging why sender human-authentication ("click to confirm you're not a spammer") emails were never being sent on a live instance, even though messages were correctly marked as needing one. Running `agentj:send-auth-mail-token` manually worked immediately and sent the email. Checking `/etc/cron.d/agentj` inside the running container showed `-rw-rw-r--` (664) instead of the `-rw-r--r--` (644) tracked in git.

## Fix

Add `RUN chmod 644 /etc/cron.d/agentj` right after the `COPY`, so the resulting image has deterministic, correct permissions regardless of the build machine's umask.

## Test plan

- [x] Build the `app` image and confirm `/etc/cron.d/agentj` is `644` inside the resulting container regardless of the host umask (e.g. build once with `umask 002`).
- [x] Confirm cron actually executes the AgentJ jobs (e.g. observe `agentj:send-auth-mail-token` run automatically within a minute, instead of only working when invoked manually).
