### PR TITLE
fix(amavis): recognize protected domains as local (fix open-relay false positive)

### DIFF
--- a/amavis/conf/amavis/amavisd.conf
+++ b/amavis/conf/amavis/amavisd.conf
@@ -138,5 +138,11 @@ $policy_bank{'AM.PDP-INET'} = {
   inet_acl => [qw(  [::1] 127.0.0.1 $IPV4_NETWORK)],  # restrict access to these IP addresses
   auth_required_release => 1,  # require secret_id for amavisd-release
  };
+
+## Recognize AgentJ-protected domains (from the 'domain' table) as local,
+## instead of relying on /etc/mailname (which is the gateway's own hostname).
+## Without this, every inbound message is misclassified as a suspected open
+## relay and silently discarded.
+@local_domains_maps = ( ['sql:SELECT 1 FROM domain WHERE domain=lower(?) AND active=1'] );
 #------------ Do not modify anything below this line -------------
 1;  # ensure a defined return

--- a/amavis/conf/amavis/amavisd.conf
+++ b/amavis/conf/amavis/amavisd.conf
@@ -142,7 +142,22 @@ $policy_bank{'AM.PDP-INET'} = {
 ## Recognize AgentJ-protected domains (from the 'domain' table) as local,
 ## instead of relying on /etc/mailname (which is the gateway's own hostname).
 ## Without this, every inbound message is misclassified as a suspected open
-## relay and silently discarded.
-@local_domains_maps = ( ['sql:SELECT 1 FROM domain WHERE domain=lower(?) AND active=1'] );
+## relay and silently discarded. Queried once at amavis startup (not
+## per-message): restart amavis after adding/removing/deactivating a domain.
+{
+  require DBI;
+  my @protected_domains;
+  eval {
+    my ($dsn, $user, $pass) = @{ $lookup_sql_dsn[0] };
+    my $dbh = DBI->connect($dsn, $user, $pass, { RaiseError => 1, PrintError => 0 });
+    my $sth = $dbh->prepare('SELECT domain FROM domain WHERE active=1');
+    $sth->execute;
+    while (my ($d) = $sth->fetchrow_array) {
+      push @protected_domains, '.' . lc($d);
+    }
+    $dbh->disconnect;
+  };
+  @local_domains_acl = @protected_domains if @protected_domains;
+}
 #------------ Do not modify anything below this line -------------
 1;  # ensure a defined return


### PR DESCRIPTION
## Summary

Fixes #537.

`/etc/amavis/conf.d/05-domain_id` (stock Debian amavisd-new package snippet) derives `@local_domains_acl` from `/etc/mailname`, i.e. the gateway's own hostname (`antispam.<customer-domain>.fr`), not the actual protected domain (`<customer-domain>.fr`, stored in the `domain` SQL table). Every real recipient is therefore classified as "nonlocal", which combined with `$interface_policy{'10024'} = 'MYNET'` trips amavisd-new's open-relay heuristic on every single inbound message — resulting in 100% of mail being discarded and quarantined as `DiscardedOpenRelay`, regardless of spam score.

This adds a block to `amavis/conf/amavis/amavisd.conf` (loaded after `05-domain_id`, so it overrides it) that queries the `domain` table once at amavis startup and populates `@local_domains_acl` from the active, AgentJ-managed domains — keeping local-domain recognition in sync with the admin panel instead of the gateway's own hostname.

Note: an initial attempt used `@local_domains_maps` with an inline `sql:...` string, but amavisd-new's SQL-map mechanism only supports a fixed set of built-in named clauses (`%sql_clause`) — a raw array entry there is parsed as a literal ACL pattern and silently never matches. Second commit replaces that with a plain Perl block using the existing `@lookup_sql_dsn`, the same ACL-style mechanism the stock `05-domain_id` snippet already uses successfully.

## Verified live

Applied on a production instance (`agentj-amavis-1`): before the fix, a legitimate message to a protected-domain recipient logged `Blocked SPAM {DiscardedOpenRelay,Quarantined}, MYNET ... Open relay?` even with a non-spam score (Hits: -1.91). After the fix, the same address logs `lookup [local_domains] => true ... matching_key=".<domain>"` and the message is no longer tagged `DiscardedOpenRelay` (a separate, unrelated per-domain spam/whitelist policy may still apply afterwards, as expected).

## Test plan

- [ ] Deploy a domain with `srv_smtp`/`transport` pointing to a backend mailbox host, MX pointed at the gateway
- [ ] Send inbound mail from an external sender to that domain
- [ ] Confirm the message is no longer tagged `DiscardedOpenRelay` in the amavis log / quarantine list
- [ ] Restart amavis after adding/removing/deactivating a domain and confirm `@local_domains_acl` picks up the change