### PR TITLE
feat: allow banning a sender from the report email without login

### DIFF
--- a/app/src/Command/SendReportMailCommand.php
+++ b/app/src/Command/SendReportMailCommand.php
@@ -224,11 +224,19 @@ class SendReportMailCommand extends Command
                 'recipientId' => $messageRecipient->getAddress()->getId(),
             ], UrlGeneratorInterface::ABSOLUTE_URL);
 
+            $urlBan = $this->urlGenerator->generate('portal_message_banned', [
+                'token' => $token,
+                'partitionTag' => $messageRecipient->getPartitionTag(),
+                'mailId' => $messageRecipient->getMailId(),
+                'recipientId' => $messageRecipient->getAddress()->getId(),
+            ], UrlGeneratorInterface::ABSOLUTE_URL);
+
             $bodyMessage = $messageTemplate;
             $bodyMessage = str_replace('[MESSAGE_SENDER]', $this->escape($message->getFromAddr()), $bodyMessage);
             $bodyMessage = str_replace('[MESSAGE_SUBJECT]', $this->escape($message->getSubject()), $bodyMessage);
             $bodyMessage = str_replace('[URL_MESSAGE_AUTHORIZE_SENDER]', $urlAuthorize, $bodyMessage);
             $bodyMessage = str_replace('[URL_MESSAGE_RESTORE]', $urlRestore, $bodyMessage);
+            $bodyMessage = str_replace('[URL_MESSAGE_BAN]', $urlBan, $bodyMessage);
 
             $bodyMessages .= $bodyMessage;
         }

--- a/app/src/Controller/Domain/CustomisationController.php
+++ b/app/src/Controller/Domain/CustomisationController.php
@@ -133,6 +133,7 @@ class CustomisationController extends AbstractController
                 'MESSAGE_SUBJECT' => new TranslatableMessage('Entities.Domain.labels.dynamicsVariables.MESSAGE_SUBJECT'),
                 'URL_MESSAGE_AUTHORIZE_SENDER' => new TranslatableMessage('Entities.Domain.labels.dynamicsVariables.URL_MESSAGE_AUTHORIZE_SENDER'),
                 'URL_MESSAGE_RESTORE' => new TranslatableMessage('Entities.Domain.labels.dynamicsVariables.URL_MESSAGE_RESTORE'),
+                'URL_MESSAGE_BAN' => new TranslatableMessage('Entities.Domain.labels.dynamicsVariables.URL_MESSAGE_BAN'),
             ],
             // phpcs:enable Generic.Files.LineLength
         ]);

--- a/app/src/Controller/Portal/MessageController.php
+++ b/app/src/Controller/Portal/MessageController.php
@@ -70,6 +70,53 @@ class MessageController extends AbstractController
     }
 
     #[Route(
+        path: '/portal/{token}/message/{partitionTag}/{mailId}/{recipientId}/banned',
+        name: 'portal_message_banned',
+    )]
+    public function banned(
+        string $token,
+        int $partitionTag,
+        string $mailId,
+        int $recipientId,
+    ): Response {
+        $result = $this->messageService->decryptReleaseToken($token);
+
+        if (!$result) {
+            throw $this->createNotFoundException('The token is invalid.');
+        }
+
+        $user = $result[0];
+        $tokenMailId = $result[1];
+
+        if ($tokenMailId !== null && $tokenMailId !== $mailId) {
+            throw $this->createNotFoundException('The token is invalid.');
+        }
+
+        $messageRecipient = $this->messageRecipientRepository->findOneBy([
+            'partitionTag' => $partitionTag,
+            'mailId' => $mailId,
+            'address' => $recipientId,
+        ]);
+
+        if (!$messageRecipient) {
+            throw $this->createNotFoundException('Message recipient does not exist');
+        }
+
+        $this->checkMailAccess($user, $messageRecipient);
+
+        $result = $this->messageService->banSenderForRecipient(
+            $messageRecipient,
+            Entity\SenderRule::TYPE_USER,
+        );
+
+        if ($result) {
+            $this->logService->addLog('banned', $mailId);
+        }
+
+        return $this->render('portal/messages/banned.html.twig');
+    }
+
+    #[Route(
         path: '/portal/{token}/message/{partitionTag}/{mailId}/{recipientId}/restore',
         name: 'portal_message_restore',
     )]

--- a/app/src/Entity/BaseMessageRecipient.php
+++ b/app/src/Entity/BaseMessageRecipient.php
@@ -4,6 +4,7 @@ namespace App\Entity;
 
 use App\Amavis\DeliveryStatus;
 use App\Amavis\MessageStatus;
+use App\Util\ResourceHelper;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Translation\TranslatableMessage;
@@ -24,7 +25,7 @@ class BaseMessageRecipient
     #[ORM\Column(name: 'mail_id', type: Types::BINARY, length: 255, nullable: false)]
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'NONE')]
-    private string $mailId; /** @phpstan-ignore property.onlyRead */
+    private mixed $mailId = null; /** @phpstan-ignore property.onlyRead */
 
     #[ORM\Column(name: 'rseqnum', type: 'integer', nullable: false)]
     #[ORM\Id]
@@ -76,7 +77,13 @@ class BaseMessageRecipient
 
     public function getMailId(): string
     {
-        return $this->mailId;
+        // Doctrine's Types::BINARY always hydrates the column as a PHP
+        // stream resource (see DBAL's BinaryType::convertToPHPValue()), not
+        // a string, hence the mixed property above and the conversion here.
+        // Without it, callers that embed getMailId() in a URL
+        // (authorize/restore/ban links) end up with the literal
+        // "Resource id #N" instead of the actual id.
+        return ResourceHelper::toString($this->mailId) ?? '';
     }
 
     public function getRseqnum(): ?int

--- a/app/src/Entity/BaseMessageRecipient.php
+++ b/app/src/Entity/BaseMessageRecipient.php
@@ -25,7 +25,7 @@ class BaseMessageRecipient
     #[ORM\Column(name: 'mail_id', type: Types::BINARY, length: 255, nullable: false)]
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'NONE')]
-    private mixed $mailId = null; /** @phpstan-ignore property.onlyRead */
+    private mixed $mailId = null;
 
     #[ORM\Column(name: 'rseqnum', type: 'integer', nullable: false)]
     #[ORM\Id]

--- a/app/templates/portal/messages/authorized.html.twig
+++ b/app/templates/portal/messages/authorized.html.twig
@@ -10,12 +10,6 @@
             <p>
                 {{ 'Portal.Messages.authorized.senderAuthorized' | trans }}
             </p>
-
-            <p>
-                <a class="btn btn-primary" href="{{ path('message', { type: 'authorized' }) }}">
-                    {{ 'Portal.Messages.authorized.backToMessages' | trans }}
-                </a>
-            </p>
         </div>
     </div>
 

--- a/app/templates/portal/messages/banned.html.twig
+++ b/app/templates/portal/messages/banned.html.twig
@@ -10,12 +10,6 @@
             <p>
                 {{ 'Portal.Messages.banned.senderBanned' | trans }}
             </p>
-
-            <p>
-                <a class="btn btn-primary" href="{{ path('message', { type: 'banned' }) }}">
-                    {{ 'Portal.Messages.banned.backToMessages' | trans }}
-                </a>
-            </p>
         </div>
     </div>
 

--- a/app/templates/portal/messages/banned.html.twig
+++ b/app/templates/portal/messages/banned.html.twig
@@ -1,0 +1,27 @@
+{% extends 'base_security.html.twig' %}
+
+{% block body %}
+    <div class="h-100 ">
+        <div class="col-lg-4 col-md-6 col-sm-12 text-center pb-4 m-auto login">
+            <div>
+                <img src="{{ asset('img/agent-j-logo-desktop.svg') }}" alt="AgentJ">
+            </div>
+
+            <p>
+                {{ 'Portal.Messages.banned.senderBanned' | trans }}
+            </p>
+
+            <p>
+                <a class="btn btn-primary" href="{{ path('message', { type: 'banned' }) }}">
+                    {{ 'Portal.Messages.banned.backToMessages' | trans }}
+                </a>
+            </p>
+        </div>
+    </div>
+
+    <style>
+        img {
+            max-width: 100%;
+        }
+    </style>
+{% endblock %}

--- a/app/templates/portal/messages/restore.html.twig
+++ b/app/templates/portal/messages/restore.html.twig
@@ -10,12 +10,6 @@
             <p>
                 {{ 'Portal.Messages.restore.messageRestored' | trans }}
             </p>
-
-            <p>
-                <a class="btn btn-primary" href="{{ path('message', { type: 'restored' }) }}">
-                    {{ 'Portal.Messages.restore.backToMessages' | trans }}
-                </a>
-            </p>
         </div>
     </div>
 

--- a/app/templates/report/table_mail_msgs.html.twig
+++ b/app/templates/report/table_mail_msgs.html.twig
@@ -48,6 +48,23 @@
             </div>
           </td>
 
+          <td width="100" style="min-width: 100px;">
+            <div style="width: 100px;">
+              <a href="{{ url('portal_message_banned',{'token':token,'partitionTag':messageRecipient.partitionTag,'mailId':messageRecipient.mailId,'recipientId':messageRecipient.address.id}) }}"
+                 title="{{ 'Message.Actions.BannedSender'|trans(locale: locale) }}" style="font-size:16px;
+                 -moz-border-radius: 5px;
+                 -webkit-border-radius: 5px;
+                 border-radius: 5px;
+                 line-height: 16px;
+                 background-color: #E76D6D;
+                 padding: 5px;
+                 color: #fff;
+                 text-decoration: none;
+                 ">
+                {{ 'Message.Actions.Banned'|trans(locale: locale) }}</a>
+            </div>
+          </td>
+
         </tr>
       {% endfor %}
 

--- a/app/translations/messages+intl-icu.en.yaml
+++ b/app/translations/messages+intl-icu.en.yaml
@@ -72,6 +72,7 @@ Entities.Domain.labels.dynamicsVariables.NB_SPAMMED_MESSAGES: 'Number of message
 Entities.Domain.labels.dynamicsVariables.NB_UNTREATED_MESSAGES: 'Number of untreated messages'
 Entities.Domain.labels.dynamicsVariables.URL_HUMAN_AUTHENTICATION: 'Link to the human authentication page'
 Entities.Domain.labels.dynamicsVariables.URL_MESSAGE_AUTHORIZE_SENDER: "URL to authorize the message's sender"
+Entities.Domain.labels.dynamicsVariables.URL_MESSAGE_BAN: "URL to ban the message's sender"
 Entities.Domain.labels.dynamicsVariables.URL_MESSAGE_RESTORE: 'URL to recover the message'
 Entities.Domain.labels.dynamicsVariables.URL_MSGS: 'Link to pending emails'
 Entities.Domain.labels.dynamicsVariables.USERNAME: "User's name"

--- a/app/translations/messages+intl-icu.en.yaml
+++ b/app/translations/messages+intl-icu.en.yaml
@@ -505,11 +505,8 @@ Navigation.userlist.localUsers: Administrator
 Navigation.userlist.title: Users
 Navigation.virus: Virus
 Navigation.whitelist: 'Authorized senders'
-Portal.Messages.authorized.backToMessages: 'See my authorized mails'
 Portal.Messages.authorized.senderAuthorized: 'The address is now authorized.'
-Portal.Messages.banned.backToMessages: 'See my banned mails'
 Portal.Messages.banned.senderBanned: 'The address is now banned.'
-Portal.Messages.restore.backToMessages: 'See my recovered mails'
 Portal.Messages.restore.messageRestored: 'Message successfully recovered.'
 Search.AdvancedFilter: 'Advanced filter'
 Search.AmavisOutput: 'Amavis Output'

--- a/app/translations/messages+intl-icu.en.yaml
+++ b/app/translations/messages+intl-icu.en.yaml
@@ -506,6 +506,8 @@ Navigation.virus: Virus
 Navigation.whitelist: 'Authorized senders'
 Portal.Messages.authorized.backToMessages: 'See my authorized mails'
 Portal.Messages.authorized.senderAuthorized: 'The address is now authorized.'
+Portal.Messages.banned.backToMessages: 'See my banned mails'
+Portal.Messages.banned.senderBanned: 'The address is now banned.'
 Portal.Messages.restore.backToMessages: 'See my recovered mails'
 Portal.Messages.restore.messageRestored: 'Message successfully recovered.'
 Search.AdvancedFilter: 'Advanced filter'

--- a/app/translations/messages+intl-icu.fr.yaml
+++ b/app/translations/messages+intl-icu.fr.yaml
@@ -506,6 +506,8 @@ Navigation.virus: 'Virus détectés'
 Navigation.whitelist: 'Expéditeurs autorisés'
 Portal.Messages.authorized.backToMessages: 'Voir mes mails autorisés'
 Portal.Messages.authorized.senderAuthorized: 'L’adresse est désormais autorisée.'
+Portal.Messages.banned.backToMessages: 'Voir mes mails bannis'
+Portal.Messages.banned.senderBanned: "L'adresse est désormais bannie."
 Portal.Messages.restore.backToMessages: 'Voir mes mails récupérés'
 Portal.Messages.restore.messageRestored: 'Message récupéré avec succès.'
 Search.AdvancedFilter: 'Filtres avancés'

--- a/app/translations/messages+intl-icu.fr.yaml
+++ b/app/translations/messages+intl-icu.fr.yaml
@@ -505,11 +505,8 @@ Navigation.userlist.localUsers: Administrateur
 Navigation.userlist.title: Utilisateurs
 Navigation.virus: 'Virus détectés'
 Navigation.whitelist: 'Expéditeurs autorisés'
-Portal.Messages.authorized.backToMessages: 'Voir mes mails autorisés'
 Portal.Messages.authorized.senderAuthorized: 'L’adresse est désormais autorisée.'
-Portal.Messages.banned.backToMessages: 'Voir mes mails bannis'
 Portal.Messages.banned.senderBanned: "L'adresse est désormais bannie."
-Portal.Messages.restore.backToMessages: 'Voir mes mails récupérés'
 Portal.Messages.restore.messageRestored: 'Message récupéré avec succès.'
 Search.AdvancedFilter: 'Filtres avancés'
 Search.AmavisOutput: 'Score Amavis'

--- a/app/translations/messages+intl-icu.fr.yaml
+++ b/app/translations/messages+intl-icu.fr.yaml
@@ -72,6 +72,7 @@ Entities.Domain.labels.dynamicsVariables.NB_SPAMMED_MESSAGES: 'Nombre de message
 Entities.Domain.labels.dynamicsVariables.NB_UNTREATED_MESSAGES: 'Nombre de messages non traités'
 Entities.Domain.labels.dynamicsVariables.URL_HUMAN_AUTHENTICATION: "Lien vers la page d'authentification humaine"
 Entities.Domain.labels.dynamicsVariables.URL_MESSAGE_AUTHORIZE_SENDER: "URL autorisant l'expéditeur du message"
+Entities.Domain.labels.dynamicsVariables.URL_MESSAGE_BAN: "URL bannissant l'expéditeur du message"
 Entities.Domain.labels.dynamicsVariables.URL_MESSAGE_RESTORE: 'URL récupérant le message'
 Entities.Domain.labels.dynamicsVariables.URL_MSGS: 'Lien vers les mails en attente'
 Entities.Domain.labels.dynamicsVariables.USERNAME: "Nom de l'utilisateur"


### PR DESCRIPTION
## Summary
- The report email already lets a recipient authorize a sender or release a message straight from the email, via the public token-authenticated `/portal` routes — no account/login needed.
- There was no equivalent way to reject/ban a sender the same way; doing so required logging into the web app.
- Adds a `portal_message_banned` route, mirroring the existing `portal_message_authorized` / `portal_message_restore` routes (same signed release token, same access check), calling `MessageService::banSenderForRecipient`.
- Adds a third "Ban" button to the report email template (`report/table_mail_msgs.html.twig`) and a confirmation page, with FR/EN translations.

## Test plan
- [ ] `agentj:report-send-mail` sends a report email containing the 3 buttons (Authorize / Restore / Ban) for a user with pending quarantined mail
- [ ] Clicking "Ban" from the email (logged out) bans the sender for that recipient and shows the confirmation page
- [ ] Existing "Authorize" / "Restore" portal links still work unaffected
- [ ] An expired or tampered token is still rejected with 404, same as the existing routes