### PR TITLE
fix(forms): make label wrapper full width instead of col-sm-2

### DIFF
--- a/app/templates/forms/form_layout.html.twig
+++ b/app/templates/forms/form_layout.html.twig
@@ -43,6 +43,7 @@
             {% set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' ' ~ block('form_label_class'))|trim}) %}
         {% endif %}
         {% set label_attr = label_attr|merge({class: label_attr.class|replace({'col-sm-2': ''})|trim}) %}
-        {{- parent() -}}
+        {% set label_html %}{{- parent() -}}{% endset %}
+        {{- label_html|replace({'<div class="col-sm-2">': '<div class="col-sm-12">'})|raw -}}
     {% endif %}
 {% endblock form_label %}


### PR DESCRIPTION
## Summary
- The custom `form_label` block in `app/templates/forms/form_layout.html.twig` already forces the `<label>` itself to `col-sm-12`, but the wrapping `<div>` still gets `col-sm-2` from the horizontal Bootstrap theme's `form_label_class` block. For long labels (e.g. domain customisation fields like "Texte du mail de validation de l'email avec le lien d'authentification humaine" or "Message du rapport"), the label text gets squeezed into a narrow 2/12 column instead of spanning the row.
- Fix: capture the parent label markup and swap the wrapping div's class from `col-sm-2` to `col-sm-12`, without touching the shared `form_label_class` block (which is still used, unaffected, by `checkbox_row`/`submit_row`/`reset_row` spacer divs).

**Note:** this branch is based on the last commit before `f8540c3b` ("fix: change bootstrap layout to fix form width", issue #526), not on current `main`. That commit switches the theme to `bootstrap_4_layout.html.twig`, but `main` still calls `block('form_label_class')` unconditionally in `form_label`, and that block no longer exists outside the horizontal themes — this throws a Twig `RuntimeError` ("Block ... does not exist") for essentially every regular form field. This PR targets the behavior currently deployed in production; whoever picks up #526 will likely want to drop this diff (or adapt it) once that work lands cleanly.

## Test plan
- [x] `bin/console lint:twig templates/forms/form_layout.html.twig`
- [x] Verified live (temporary copy into the running container, reverted after): `domain/{id}/customisation/human-authentication` and `domain/{id}/customisation/report` now render the label div as `col-sm-12`
- [x] Verified no regression on `domain/{id}/edit` (checkbox rows keep their `col-sm-2`/`col-sm-10` split) and `/message` list page