### PR TITLE
fix: restrict sender rule imports to admins

### DIFF
--- a/app/tests/Controller/SenderRuleImportSecurityTest.php
+++ b/app/tests/Controller/SenderRuleImportSecurityTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Tests\Controller;
+
+use App\Tests\Factory\UserFactory;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+class SenderRuleImportSecurityTest extends WebTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    public function testUserCannotAccessSenderRuleImport(): void
+    {
+        $client = static::createClient();
+        $user = UserFactory::new()->user()->create();
+        $client->loginUser($user);
+
+        $client->request(Request::METHOD_POST, '/rules/admin/import/W');
+
+        self::assertResponseStatusCodeSame(403);
+    }
+}


### PR DESCRIPTION
## Related issue(s)
N/A

## How to test manually
Automatic test added. Try to post on /rules/admin/import/W on an account without ADMIN rights

## Reviewer checklist

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works on both Firefox and Chrome
- [x] Tests are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
