### PR TITLE
feat: Add manual sender rules

### DIFF
--- a/app/src/Controller/ImportController.php
+++ b/app/src/Controller/ImportController.php
@@ -37,7 +37,6 @@ class ImportController extends AbstractController
         $form = $this->createForm(ImportType::class, null, [
             'action' => $this->generateUrl('import_user_email'),
         ]);
-        $form->remove('domains');
 
         $form->handleRequest($request);
         if ($form->isSubmitted() && $form->isValid()) {
@@ -228,7 +227,6 @@ class ImportController extends AbstractController
         $form = $this->createForm(ImportType::class, null, [
             'action' => $this->generateUrl('import_user_alias'),
         ]);
-        $form->remove('domains');
 
         $form->handleRequest($request);
         if ($form->isSubmitted() && $form->isValid()) {

--- a/app/src/Controller/SenderRuleController.php
+++ b/app/src/Controller/SenderRuleController.php
@@ -3,17 +3,22 @@
 namespace App\Controller;
 
 use App\Entity\Domain;
-use App\Entity\RuleAddress;
 use App\Entity\SenderRule;
 use App\Entity\User;
 use App\Form\ActionsFilterType;
 use App\Form\ImportType;
+use App\Form\SenderRuleType;
+use App\Repository\DomainRepository;
 use App\Repository\SenderRuleRepository;
+use App\Repository\UserRepository;
 use App\Service\LogService;
 use App\Service\Referrer;
+use App\Service\SenderRuleService;
 use Doctrine\ORM\EntityManagerInterface;
 use Knp\Component\Pager\PaginatorInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -27,6 +32,7 @@ class SenderRuleController extends AbstractController
         private TranslatorInterface $translator,
         private EntityManagerInterface $em,
         private Referrer $referrer,
+        private UserRepository $userRepository,
     ) {
     }
 
@@ -95,6 +101,101 @@ class SenderRuleController extends AbstractController
         ]);
     }
 
+    #[Route(path: '/rules/new/{type}', name: 'sender_rules_new', requirements: ['type' => 'W|B'], methods: 'GET')]
+    public function newSenderRule(string $type, DomainRepository $domainRepository): Response
+    {
+        /** @var User $user */
+        $user = $this->getUser();
+        $form = $this->createSenderRuleForm($type, $user, $domainRepository);
+
+        return $this->render('sender_rule/new.html.twig', [
+            'senderRuleType' => $type,
+            'form' => $form->createView(),
+        ]);
+    }
+
+    #[Route(path: '/rules/new/{type}', name: 'sender_rules_create', requirements: ['type' => 'W|B'], methods: 'POST')]
+    public function createSenderRule(
+        string $type,
+        Request $request,
+        DomainRepository $domainRepository,
+        SenderRuleService $senderRuleService,
+    ): JsonResponse {
+        /** @var User $user */
+        $user = $this->getUser();
+        $form = $this->createSenderRuleForm($type, $user, $domainRepository);
+        $form->handleRequest($request);
+
+        if (!$form->isSubmitted() || !$form->isValid()) {
+            $errors = iterator_to_array($form->getErrors(true), false);
+
+            return new JsonResponse([
+                'status' => 'danger',
+                'message' => $errors
+                    ? $errors[0]->getMessage()
+                    : $this->translator->trans('Generics.flash.genericFormError'),
+            ]);
+        }
+
+        /** @var array{email: string, domain?: Domain} $data */
+        $data = $form->getData();
+        $recipient = $user;
+        $source = SenderRule::TYPE_USER;
+        $isAdmin = $this->isGranted('ROLE_ADMIN');
+
+        if ($isAdmin) {
+            $domain = $data['domain'] ?? null;
+            $domainName = $domain?->getDomain();
+            $recipient = $domainName ? $this->userRepository->findDomainUser($domainName) : null;
+            $source = SenderRule::TYPE_ADMIN;
+        }
+
+        $created = $recipient && ($isAdmin
+            ? $senderRuleService->createOrUpdateForRecipient(
+                $data['email'],
+                $recipient,
+                $type === 'W' ? 'accept' : 'block',
+                $source,
+            )
+            : $senderRuleService->createOrUpdateForUserAndAliases(
+                $data['email'],
+                $recipient,
+                $type === 'W' ? 'accept' : 'block',
+                $source,
+            ));
+
+        if (!$created) {
+            return new JsonResponse([
+                'status' => 'danger',
+                'message' => $this->translator->trans('Generics.flash.genericFormError'),
+            ]);
+        }
+
+        return new JsonResponse([
+            'status' => 'success',
+            'message' => $this->translator->trans(
+                $type === 'W' ? 'Message.Flash.senderAuthorized' : 'Message.Flash.senderBanned',
+            ),
+        ]);
+    }
+
+    /**
+     * @return FormInterface<array{email: string, domain?: Domain}>
+     */
+    private function createSenderRuleForm(
+        string $type,
+        User $user,
+        DomainRepository $domainRepository,
+    ): FormInterface {
+        $isAdmin = $this->isGranted('ROLE_ADMIN');
+
+        return $this->createForm(SenderRuleType::class, null, [
+            'action' => $this->generateUrl('sender_rules_create', ['type' => $type]),
+            'attr' => ['class' => 'modal-ajax-form'],
+            'domains' => $isAdmin ? $domainRepository->findActiveForUser($user) : [],
+            'is_admin' => $isAdmin,
+        ]);
+    }
 
     #[Route(path: '/rules/{rid}/{sid}/{priority}/delete', name: 'sender_rules_delete', methods: 'GET')]
     public function deleteAction(
@@ -120,19 +221,8 @@ class SenderRuleController extends AbstractController
         int $priority,
         SenderRuleRepository $senderRuleRepository,
     ): void {
-        $mainUser = $this->em->getRepository(User::class)->find($userId);
-        $userAndAliases = [];
-
-        // if address in an alias we get the target mail
-        if ($mainUser && $mainUser->getOriginalUser()) {
-            $mainUser = $mainUser->getOriginalUser();
-        }
-
-        // we check if aliases exist
-        if ($mainUser) {
-            $userAndAliases = $this->em->getRepository(User::class)->findBy(['originalUser' => $mainUser->getId()]);
-            array_unshift($userAndAliases, $mainUser);
-        }
+        $user = $this->userRepository->find($userId);
+        $userAndAliases = $user ? $this->userRepository->findUserAndAliases($user) : [];
 
         foreach ($userAndAliases as $userOrAlias) {
             $senderRuleRepository->delete($userOrAlias->getId(), $senderRuleAddressId, $priority);
@@ -170,16 +260,22 @@ class SenderRuleController extends AbstractController
     }
 
     #[Route(path: '/rules/admin/import/{type}', name: 'sender_rules_import', options: ['expose' => true])]
-    public function importSenderRuleAction(Request $request, string $type): Response
-    {
+    public function importSenderRuleAction(
+        Request $request,
+        string $type,
+        DomainRepository $domainRepository,
+        SenderRuleService $senderRuleService,
+    ): Response {
         if ($type !== 'W' && $type !== 'B') {
             return new Response("Type has to be either `W` or `B`", 422);
         }
         $rule = $type === 'W' ? 'accept' : 'block';
 
+        /** @var User $user */
+        $user = $this->getUser();
         $form = $this->createForm(ImportType::class, null, [
             'action' => $this->generateUrl('sender_rules_import', ['type' => $type]),
-            'user' => $this->getUser()
+            'domains' => $domainRepository->findActiveForUser($user),
         ]);
         $form->handleRequest($request);
 
@@ -188,7 +284,11 @@ class SenderRuleController extends AbstractController
             if ($fileUpload->getClientMimeType() == "text/plain") {
                 $filename = 'import-sender-rules-agentj-' . time() . ".txt";
                 $file = $fileUpload->move('/tmp/', $filename);
-                $this->importSenderRule($file->getPathname(), $form->get('domain')->getData(), $rule);
+                $senderRuleService->importFile(
+                    $file->getPathname(),
+                    $form->get('domain')->getData(),
+                    $rule,
+                );
                 $this->addFlash('success', new TranslatableMessage('Entities.Import.SenderRule.success'));
             } else {
                 $this->addFlash('danger', new TranslatableMessage('Generics.flash.BadImportFormat'));
@@ -202,78 +302,5 @@ class SenderRuleController extends AbstractController
             'form' => $form,
             'senderRuleType' => $type,
         ]);
-    }
-
-    /**
-     * @param 'accept'|'block' $rule
-     */
-    private function importSenderRule(string $pathFile, Domain $domain, string $rule): void
-    {
-        $senderRules = [];
-        if (($handle = fopen($pathFile, "r"))) {
-            while (($data = fgets($handle, 4096)) !== false) {
-                $data = $this->sanitizeImportedData($data);
-
-                if ($data === null) {
-                    continue;
-                }
-
-                $senderRuleAddress = $this->em->getRepository(RuleAddress::class)->findOneBy(['email' => $data]);
-                // if email doesn't exist then we create email in RuleAddress
-                if (!$senderRuleAddress) {
-                    $senderRuleAddress = new RuleAddress();
-                    $senderRuleAddress->setEmail($data);
-                    $senderRuleAddress->setPriority(6);
-                    $this->em->persist($senderRuleAddress);
-                    $this->em->flush();
-                }
-
-                if (
-                    isset($senderRules[$domain->getId()]) &&
-                    in_array($senderRuleAddress->getId(), $senderRules[$domain->getId()])
-                ) {
-                    continue;
-                }
-
-                $user = $this->em->getRepository(User::class)->findOneBy(['email' =>  '@' . $domain->getDomain()]);
-                $senderRule = $this->em->getRepository(SenderRule::class)->findOneBy([
-                    'senderRuleAddress' => $senderRuleAddress,
-                    'user' => $user,
-                ]);
-                if (!$senderRule) {
-                    $senderRule = new SenderRule($user, $senderRuleAddress);
-                }
-
-                $senderRule->setWbRule($rule);
-                $senderRule->setPriority(SenderRule::PRIORITY_USER);
-                $senderRule->setType(SenderRule::TYPE_IMPORT);
-                $this->em->persist($senderRule);
-                $senderRules[$domain->getId()][] = $senderRuleAddress->getId();
-            }
-
-            $this->em->flush();
-        }
-    }
-
-    private function sanitizeImportedData(string $data): ?string
-    {
-        $data = trim($data);
-
-        $email = filter_var($data, FILTER_VALIDATE_EMAIL, FILTER_FLAG_EMAIL_UNICODE);
-        if ($email !== false) {
-            return $email;
-        }
-
-        // This allows domains to be imported in both formats: "example.org" and "@example.org".
-        if (str_starts_with($data, '@')) {
-            $data = substr($data, 1);
-        }
-
-        $domain = filter_var($data, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME);
-        if ($domain !== false) {
-            return '@' . $domain;
-        }
-
-        return null;
     }
 }

--- a/app/src/Entity/User.php
+++ b/app/src/Entity/User.php
@@ -86,7 +86,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
 
     #[ORM\ManyToOne(targetEntity: User::class, inversedBy: 'aliases')]
     #[ORM\JoinColumn(name: 'original_user_id', nullable: true, onDelete: 'CASCADE')]
-    private ?User $originalUser;
+    private ?User $originalUser = null;
 
     /**
      * @var Collection<int, User>
@@ -397,6 +397,17 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     public function getOriginalUser(): ?self
     {
         return $this->originalUser;
+    }
+
+    public function getMainUser(): self
+    {
+        $mainUser = $this;
+
+        while ($mainUser->getOriginalUser()) {
+            $mainUser = $mainUser->getOriginalUser();
+        }
+
+        return $mainUser;
     }
 
     public function setOriginalUser(?self $originalUser): self

--- a/app/src/Form/SenderRuleType.php
+++ b/app/src/Form/SenderRuleType.php
@@ -3,25 +3,34 @@
 namespace App\Form;
 
 use App\Entity\Domain;
+use App\Validator\Constraints\SenderAddress;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\FileType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Translation\TranslatableMessage;
+use Symfony\Component\Validator\Constraints\NotBlank;
 
-class ImportType extends AbstractType
+/**
+ * @extends AbstractType<array{email: string, domain?: Domain}>
+ */
+class SenderRuleType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
-        $builder->add('attachment', FileType::class, ['label' => false]);
+        $builder->add('email', TextType::class, [
+            'label' => new TranslatableMessage('Generics.fields.sender'),
+            'constraints' => [new NotBlank(), new SenderAddress()],
+        ]);
 
-        if (is_array($options['domains'])) {
+        if ($options['is_admin'] === true) {
             $builder->add('domain', EntityType::class, [
                 'class' => Domain::class,
                 'choices' => $options['domains'],
                 'label' => new TranslatableMessage('Entities.SenderRule.fields.domain'),
-                'multiple' => false,
+                'placeholder' => new TranslatableMessage('Generics.actions.chooseDomain'),
+                'required' => true,
                 'attr' => ['class' => 'select2'],
             ]);
         }
@@ -31,8 +40,10 @@ class ImportType extends AbstractType
     {
         $resolver->setDefaults([
             'data_class' => null,
-            'domains' => null,
+            'domains' => [],
+            'is_admin' => false,
         ]);
-        $resolver->setAllowedTypes('domains', ['array', 'null']);
+        $resolver->setAllowedTypes('domains', 'array');
+        $resolver->setAllowedTypes('is_admin', 'bool');
     }
 }

--- a/app/src/Repository/DomainRepository.php
+++ b/app/src/Repository/DomainRepository.php
@@ -5,6 +5,7 @@ namespace App\Repository;
 use App\Entity\Domain;
 use App\Entity\User;
 use Doctrine\ORM\Query;
+use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
 
 /**
@@ -36,21 +37,39 @@ class DomainRepository extends BaseRepository
         User $currentUser,
         ?string $searchKey = null,
     ): Query {
-        $queryBuilder = $this->createQueryBuilder('d');
+        $queryBuilder = $this->createAccessibleQueryBuilder($currentUser);
 
         if ($searchKey) {
-            $queryBuilder->where('d.domain LIKE :search')
+            $queryBuilder->andWhere('d.domain LIKE :search')
                 ->setParameter('search', '%' . $searchKey . '%');
         }
+
+        return $queryBuilder->getQuery();
+    }
+
+    /**
+     * @return Domain[]
+     */
+    public function findActiveForUser(User $currentUser): array
+    {
+        return $this->createAccessibleQueryBuilder($currentUser)
+            ->andWhere('d.active = :active')
+            ->setParameter('active', true)
+            ->orderBy('d.domain', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
+
+    private function createAccessibleQueryBuilder(User $currentUser): QueryBuilder
+    {
+        $queryBuilder = $this->createQueryBuilder('d');
 
         if (!$currentUser->isSuperAdmin()) {
             $queryBuilder->andWhere(':user MEMBER OF d.users')
                 ->setParameter('user', $currentUser);
         }
 
-        $query = $queryBuilder->getQuery();
-
-        return $query;
+        return $queryBuilder;
     }
 
     /**

--- a/app/src/Repository/RuleAddressRepository.php
+++ b/app/src/Repository/RuleAddressRepository.php
@@ -15,14 +15,14 @@ class RuleAddressRepository extends BaseRepository
         parent::__construct($registry, RuleAddress::class);
     }
 
-    public function findOneOrCreateByEmail(string $email, bool $flush = true): RuleAddress
+    public function findOneOrCreateByEmail(string $email, bool $flush = true, ?int $priority = null): RuleAddress
     {
         $ruleAddress = $this->findOneBy(['email' => $email]);
 
         if (!$ruleAddress) {
             $ruleAddress = new RuleAddress();
             $ruleAddress->setEmail($email);
-            $ruleAddress->setPriority(6);
+            $ruleAddress->setPriority($priority ?? 6);
             $this->save($ruleAddress, $flush);
         }
 

--- a/app/src/Repository/SenderRuleRepository.php
+++ b/app/src/Repository/SenderRuleRepository.php
@@ -253,6 +253,7 @@ class SenderRuleRepository extends BaseRepository
         $senderRule = $this->findOneBy([
             'user' => $recipientUser,
             'senderRuleAddress' => $senderRuleAddress,
+            'priority' => $priority,
         ]);
 
         if (!$senderRule) {

--- a/app/src/Repository/UserRepository.php
+++ b/app/src/Repository/UserRepository.php
@@ -98,18 +98,23 @@ class UserRepository extends BaseRepository
      */
     public function findUserAndAliasesByAddress(Address $address): array
     {
-        $mainUser = $this->findOneByAddress($address);
+        $user = $this->findOneByAddress($address);
 
-        if (!$mainUser) {
+        if (!$user) {
             return [];
         }
 
-        // Make sure to get the main user
-        while ($mainUser->getOriginalUser()) {
-            $mainUser = $mainUser->getOriginalUser();
-        }
+        return $this->findUserAndAliases($user);
+    }
 
-        $aliases = $mainUser->getAliases()->toArray();
+    /**
+     * @return User[]
+     */
+    public function findUserAndAliases(User $user): array
+    {
+        $mainUser = $user->getMainUser();
+
+        $aliases = $this->findBy(['originalUser' => $mainUser]);
 
         return array_merge([$mainUser], $aliases);
     }

--- a/app/src/Service/SenderAddressSanitizer.php
+++ b/app/src/Service/SenderAddressSanitizer.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Service;
+
+class SenderAddressSanitizer
+{
+    public function sanitize(string $value): ?string
+    {
+        $value = strtolower(trim($value));
+
+        $email = filter_var($value, FILTER_VALIDATE_EMAIL, FILTER_FLAG_EMAIL_UNICODE);
+        if ($email !== false) {
+            return $email;
+        }
+
+        // Domains are stored with an @ prefix, regardless of the submitted format.
+        if (str_starts_with($value, '@')) {
+            $value = substr($value, 1);
+        }
+
+        $domain = filter_var($value, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME);
+        if ($domain !== false) {
+            return '@' . $domain;
+        }
+
+        return null;
+    }
+}

--- a/app/src/Service/SenderRuleService.php
+++ b/app/src/Service/SenderRuleService.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\Domain;
+use App\Entity\SenderRule;
+use App\Entity\User;
+use App\Repository\RuleAddressRepository;
+use App\Repository\SenderRuleRepository;
+use App\Repository\UserRepository;
+use Doctrine\ORM\EntityManagerInterface;
+
+class SenderRuleService
+{
+    public function __construct(
+        private SenderAddressSanitizer $senderAddressSanitizer,
+        private RuleAddressRepository $ruleAddressRepository,
+        private SenderRuleRepository $senderRuleRepository,
+        private UserRepository $userRepository,
+        private EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    /**
+     * @param 'accept'|'block' $rule
+     */
+    public function createOrUpdateForRecipient(
+        string $address,
+        User $recipient,
+        string $rule,
+        int $source,
+    ): bool {
+        return $this->createOrUpdateForRecipients($address, [$recipient], $rule, $source);
+    }
+
+    /**
+     * @param 'accept'|'block' $rule
+     */
+    public function createOrUpdateForUserAndAliases(
+        string $address,
+        User $user,
+        string $rule,
+        int $source,
+    ): bool {
+        return $this->createOrUpdateForRecipients(
+            $address,
+            $this->userRepository->findUserAndAliases($user),
+            $rule,
+            $source,
+        );
+    }
+
+    /**
+     * @param User[] $recipients
+     * @param 'accept'|'block' $rule
+     */
+    private function createOrUpdateForRecipients(
+        string $address,
+        array $recipients,
+        string $rule,
+        int $source,
+    ): bool {
+        $normalizedAddress = $this->senderAddressSanitizer->sanitize($address);
+        if ($normalizedAddress === null) {
+            return false;
+        }
+
+        $this->saveNormalized($normalizedAddress, $recipients, $rule, $source);
+
+        return true;
+    }
+
+    /**
+     * @param 'accept'|'block' $rule
+     */
+    public function importFile(string $path, Domain $domain, string $rule): void
+    {
+        $domainName = $domain->getDomain();
+        $recipient = $domainName ? $this->userRepository->findDomainUser($domainName) : null;
+        if (!$recipient) {
+            throw new \LogicException('The domain user required to create sender rules does not exist.');
+        }
+
+        $handle = fopen($path, 'r');
+        if ($handle === false) {
+            throw new \RuntimeException("Unable to open sender rules import file: {$path}");
+        }
+
+        $importedAddresses = [];
+
+        try {
+            while (($address = fgets($handle, 4096)) !== false) {
+                $normalizedAddress = $this->senderAddressSanitizer->sanitize($address);
+                if ($normalizedAddress === null || isset($importedAddresses[$normalizedAddress])) {
+                    continue;
+                }
+
+                $this->saveNormalized(
+                    $normalizedAddress,
+                    [$recipient],
+                    $rule,
+                    SenderRule::TYPE_IMPORT,
+                    flush: false,
+                );
+                $importedAddresses[$normalizedAddress] = true;
+            }
+
+            $this->entityManager->flush();
+        } finally {
+            fclose($handle);
+        }
+    }
+
+    /**
+     * @param User[] $recipients
+     * @param 'accept'|'block' $rule
+     */
+    private function saveNormalized(
+        string $normalizedAddress,
+        array $recipients,
+        string $rule,
+        int $source,
+        bool $flush = true,
+    ): void {
+        $ruleAddress = $this->ruleAddressRepository->findOneOrCreateByEmail(
+            $normalizedAddress,
+            flush: false,
+            priority: RuleAddressService::computePriority($normalizedAddress),
+        );
+
+        foreach ($recipients as $recipient) {
+            $this->senderRuleRepository->updateOrCreateRule(
+                $recipient,
+                $ruleAddress,
+                wbRule: $rule,
+                type: $source,
+                priority: SenderRule::PRIORITY_USER,
+                flush: false,
+            );
+        }
+
+        if ($flush) {
+            $this->entityManager->flush();
+        }
+    }
+}

--- a/app/src/Validator/Constraints/SenderAddress.php
+++ b/app/src/Validator/Constraints/SenderAddress.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+#[\Attribute]
+class SenderAddress extends Constraint
+{
+    public string $message = 'sender_address.invalid';
+}

--- a/app/src/Validator/Constraints/SenderAddressValidator.php
+++ b/app/src/Validator/Constraints/SenderAddressValidator.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Validator\Constraints;
+
+use App\Service\SenderAddressSanitizer;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Exception\UnexpectedValueException;
+
+class SenderAddressValidator extends ConstraintValidator
+{
+    public function __construct(
+        private SenderAddressSanitizer $senderAddressSanitizer,
+    ) {
+    }
+
+    public function validate(mixed $value, Constraint $constraint): void
+    {
+        if (!$constraint instanceof SenderAddress) {
+            throw new UnexpectedTypeException($constraint, SenderAddress::class);
+        }
+
+        if ($value === null || $value === '') {
+            return;
+        }
+
+        if (!is_string($value)) {
+            throw new UnexpectedValueException($value, 'string');
+        }
+
+        if ($this->senderAddressSanitizer->sanitize($value) === null) {
+            $this->context->buildViolation($constraint->message)->addViolation();
+        }
+    }
+}

--- a/app/templates/sender_rule/index.html.twig
+++ b/app/templates/sender_rule/index.html.twig
@@ -11,14 +11,22 @@
   {% embed 'common/blockTitleAndButtons.html.twig' %}
 
     {% block content_button_actions %}
+      <button
+        type="button"
+        data-modal-method-type="GET"
+        data-url-modal-content="{{ path('sender_rules_new', {'type': senderRuleType}) }}"
+        class="btn-open-modal btn btn-success"
+      >
+        <i class="fas fa-plus"></i>&nbsp;{{ ('Entities.SenderRule.actions.addSender' ~ senderRuleType) | trans }}
+      </button>
       {%  if is_granted('ROLE_ADMIN')%}
-        <a
-          href="#"
+        <button
+          type="button"
           data-url-modal-content="{{ path('sender_rules_import', {'type': senderRuleType})}}"
-          class="btn-open-modal btn btn-success float-right col-sm-12 col-md-4 col-lg-6"
-          >
-            <i class="fas fa-plus"></i>&nbsp;{{ 'Generics.actions.importFile' | trans }}
-        </a>
+          class="btn-open-modal btn btn-success"
+        >
+          <i class="fas fa-plus"></i>&nbsp;{{ 'Generics.actions.importFile' | trans }}
+        </button>
       {% endif %}
     {% endblock %}
 

--- a/app/templates/sender_rule/new.html.twig
+++ b/app/templates/sender_rule/new.html.twig
@@ -1,0 +1,19 @@
+{% extends 'modalTemplate.html.twig' %}
+
+{% block modalTitle %}
+  {{ ('Entities.SenderRule.actions.addSender' ~ senderRuleType) | trans }}
+{% endblock %}
+
+{% block modalContent %}
+  {{ form_start(form) }}
+    {{ form_widget(form) }}
+    <div class="d-flex justify-content-center">
+      <button type="submit" class="btn btn-primary mr-2">
+        {{ 'Generics.actions.save' | trans }}
+      </button>
+      <button type="button" class="btn btn-outline-secondary btn-close-modal">
+        {{ 'Generics.actions.cancel' | trans }}
+      </button>
+    </div>
+  {{ form_end(form) }}
+{% endblock %}

--- a/app/tests/Controller/SenderRuleControllerTest.php
+++ b/app/tests/Controller/SenderRuleControllerTest.php
@@ -2,12 +2,14 @@
 
 namespace App\Tests\Controller;
 
-use App\Entity\RuleAddress;
 use App\Entity\SenderRule;
+use App\Entity\User;
 use App\Repository\RuleAddressRepository;
 use App\Repository\SenderRuleRepository;
 use App\Service\SenderRuleService;
 use App\Tests\Factory\DomainFactory;
+use App\Tests\Factory\RuleAddressFactory;
+use App\Tests\Factory\SenderRuleFactory;
 use App\Tests\Factory\UserFactory;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
@@ -50,10 +52,7 @@ class SenderRuleControllerTest extends WebTestCase
     {
         $client = static::createClient();
         $domain = DomainFactory::createOne();
-        $domainUser = UserFactory::createOne([
-            'domain' => $domain,
-            'email' => '@' . $domain->getDomain(),
-        ]);
+        $domainUser = UserFactory::findBy(['email' => '@' . $domain->getDomain()])[0];
         $admin = UserFactory::new()->admin()->create(['domains' => [$domain]]);
         $client->loginUser($admin);
         $csrfToken = $this->getCsrfToken($client, '/rules/new/W');
@@ -70,16 +69,17 @@ class SenderRuleControllerTest extends WebTestCase
         $senderRule = $this->getSenderRule($domainUser, '@trusted.example.org');
         self::assertSame('accept', $senderRule->getWbRule());
         self::assertSame(SenderRule::TYPE_ADMIN, $senderRule->getType());
-        self::assertSame(5, $senderRule->getSid()->getPriority());
+        self::assertSame(5, $senderRule->getSenderRuleAddress()->getPriority());
     }
 
     public function testInvalidSenderAddressIsRejected(): void
     {
         $client = static::createClient();
         $user = UserFactory::new()->user()->create();
+        $initialRuleAddressCount = RuleAddressFactory::count();
         $client->loginUser($user);
-        $csrfToken = $this->getCsrfToken($client, '/rules/new/W');
 
+        $csrfToken = $this->getCsrfToken($client, '/rules/new/W');
         $client->request(Request::METHOD_POST, '/rules/new/W', [
             'sender_rule' => [
                 '_token' => $csrfToken,
@@ -89,21 +89,18 @@ class SenderRuleControllerTest extends WebTestCase
 
         self::assertResponseIsSuccessful();
         self::assertStringContainsString('"status":"danger"', (string) $client->getResponse()->getContent());
-        self::assertSame(0, $this->getRuleAddressRepository()->count([]));
+        self::assertSame($initialRuleAddressCount, RuleAddressFactory::count());
     }
 
     public function testAdminCannotCreateRuleForUnmanagedDomain(): void
     {
         $client = static::createClient();
-        $managedDomain = DomainFactory::createOne();
-        $unmanagedDomain = DomainFactory::createOne();
-        UserFactory::createOne([
-            'domain' => $unmanagedDomain,
-            'email' => '@' . $unmanagedDomain->getDomain(),
-        ]);
+        $managedDomain = DomainFactory::new()->create();
+        $unmanagedDomain = DomainFactory::new()->create();
         $admin = UserFactory::new()->admin()->create(['domains' => [$managedDomain]]);
         $client->loginUser($admin);
         $csrfToken = $this->getCsrfToken($client, '/rules/new/W');
+        $initialUserCount = UserFactory::count();
 
         $client->request(Request::METHOD_POST, '/rules/new/W', [
             'sender_rule' => [
@@ -115,7 +112,7 @@ class SenderRuleControllerTest extends WebTestCase
 
         self::assertResponseIsSuccessful();
         self::assertStringContainsString('"status":"danger"', (string) $client->getResponse()->getContent());
-        self::assertSame(0, $this->getRuleAddressRepository()->count([]));
+        self::assertSame($initialUserCount, UserFactory::count());
     }
 
     public function testImportOnlyListsDomainsManagedByAdmin(): void
@@ -150,7 +147,7 @@ class SenderRuleControllerTest extends WebTestCase
         self::assertNotNull($ruleAddress);
         $senderRuleRepository = static::getContainer()->get(SenderRuleRepository::class);
         self::assertSame(2, $senderRuleRepository->count([
-            'sid' => $ruleAddress,
+            'senderRuleAddress' => $ruleAddress,
             'priority' => SenderRule::PRIORITY_USER,
         ]));
 
@@ -160,22 +157,19 @@ class SenderRuleControllerTest extends WebTestCase
 
         self::assertResponseRedirects();
         self::assertSame(0, $senderRuleRepository->count([
-            'sid' => $ruleAddress,
+            'senderRuleAddress' => $ruleAddress,
             'priority' => SenderRule::PRIORITY_USER,
         ]));
     }
 
-    private function getSenderRule(object $recipient, string $address): SenderRule
+    private function getSenderRule(User $recipient, string $address): SenderRule
     {
-        $ruleAddress = $this->getRuleAddressRepository()->findOneBy(['email' => $address]);
-        self::assertInstanceOf(RuleAddress::class, $ruleAddress);
+        $ruleAddress = RuleAddressFactory::findBy(['email' => $address])[0];
 
-        $senderRuleRepository = static::getContainer()->get(SenderRuleRepository::class);
-        $senderRule = $senderRuleRepository->findOneBy([
-            'rid' => $recipient,
-            'sid' => $ruleAddress,
-        ]);
-        self::assertInstanceOf(SenderRule::class, $senderRule);
+        $senderRule = SenderRuleFactory::findBy([
+            'user' => $recipient,
+            'senderRuleAddress' => $ruleAddress,
+        ])[0];
 
         return $senderRule;
     }

--- a/app/tests/Controller/SenderRuleControllerTest.php
+++ b/app/tests/Controller/SenderRuleControllerTest.php
@@ -1,0 +1,196 @@
+<?php
+
+namespace App\Tests\Controller;
+
+use App\Entity\RuleAddress;
+use App\Entity\SenderRule;
+use App\Repository\RuleAddressRepository;
+use App\Repository\SenderRuleRepository;
+use App\Service\SenderRuleService;
+use App\Tests\Factory\DomainFactory;
+use App\Tests\Factory\UserFactory;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Component\HttpFoundation\Request;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+class SenderRuleControllerTest extends WebTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    public function testUserCanBlockSenderForThemself(): void
+    {
+        $client = static::createClient();
+        $user = UserFactory::new()->user()->create();
+        $client->loginUser($user);
+        $csrfToken = $this->getCsrfToken($client, '/rules/new/B');
+
+        $client->request(Request::METHOD_POST, '/rules/new/B', [
+            'sender_rule' => [
+                '_token' => $csrfToken,
+                'email' => 'blocked@example.org',
+            ],
+        ]);
+
+        self::assertResponseIsSuccessful();
+        self::assertJsonStringEqualsJsonString(
+            '{"status":"success","message":"The address is now banned"}',
+            (string) $client->getResponse()->getContent(),
+        );
+
+        $senderRule = $this->getSenderRule($user, 'blocked@example.org');
+        self::assertSame('block', $senderRule->getWbRule());
+        self::assertSame(SenderRule::TYPE_USER, $senderRule->getType());
+        self::assertSame(SenderRule::PRIORITY_USER, $senderRule->getPriority());
+    }
+
+    public function testAdminCanAuthorizeSenderDomainForManagedDomain(): void
+    {
+        $client = static::createClient();
+        $domain = DomainFactory::createOne();
+        $domainUser = UserFactory::createOne([
+            'domain' => $domain,
+            'email' => '@' . $domain->getDomain(),
+        ]);
+        $admin = UserFactory::new()->admin()->create(['domains' => [$domain]]);
+        $client->loginUser($admin);
+        $csrfToken = $this->getCsrfToken($client, '/rules/new/W');
+
+        $client->request(Request::METHOD_POST, '/rules/new/W', [
+            'sender_rule' => [
+                '_token' => $csrfToken,
+                'email' => 'trusted.example.org',
+                'domain' => $domain->getId(),
+            ],
+        ]);
+
+        self::assertResponseIsSuccessful();
+        $senderRule = $this->getSenderRule($domainUser, '@trusted.example.org');
+        self::assertSame('accept', $senderRule->getWbRule());
+        self::assertSame(SenderRule::TYPE_ADMIN, $senderRule->getType());
+        self::assertSame(5, $senderRule->getSid()->getPriority());
+    }
+
+    public function testInvalidSenderAddressIsRejected(): void
+    {
+        $client = static::createClient();
+        $user = UserFactory::new()->user()->create();
+        $client->loginUser($user);
+        $csrfToken = $this->getCsrfToken($client, '/rules/new/W');
+
+        $client->request(Request::METHOD_POST, '/rules/new/W', [
+            'sender_rule' => [
+                '_token' => $csrfToken,
+                'email' => 'not an address',
+            ],
+        ]);
+
+        self::assertResponseIsSuccessful();
+        self::assertStringContainsString('"status":"danger"', (string) $client->getResponse()->getContent());
+        self::assertSame(0, $this->getRuleAddressRepository()->count([]));
+    }
+
+    public function testAdminCannotCreateRuleForUnmanagedDomain(): void
+    {
+        $client = static::createClient();
+        $managedDomain = DomainFactory::createOne();
+        $unmanagedDomain = DomainFactory::createOne();
+        UserFactory::createOne([
+            'domain' => $unmanagedDomain,
+            'email' => '@' . $unmanagedDomain->getDomain(),
+        ]);
+        $admin = UserFactory::new()->admin()->create(['domains' => [$managedDomain]]);
+        $client->loginUser($admin);
+        $csrfToken = $this->getCsrfToken($client, '/rules/new/W');
+
+        $client->request(Request::METHOD_POST, '/rules/new/W', [
+            'sender_rule' => [
+                '_token' => $csrfToken,
+                'email' => 'sender@example.org',
+                'domain' => $unmanagedDomain->getId(),
+            ],
+        ]);
+
+        self::assertResponseIsSuccessful();
+        self::assertStringContainsString('"status":"danger"', (string) $client->getResponse()->getContent());
+        self::assertSame(0, $this->getRuleAddressRepository()->count([]));
+    }
+
+    public function testImportOnlyListsDomainsManagedByAdmin(): void
+    {
+        $client = static::createClient();
+        $managedDomain = DomainFactory::createOne();
+        $unmanagedDomain = DomainFactory::createOne();
+        $admin = UserFactory::new()->admin()->create(['domains' => [$managedDomain]]);
+        $client->loginUser($admin);
+
+        $crawler = $client->request(Request::METHOD_POST, '/rules/admin/import/W');
+
+        self::assertResponseIsSuccessful();
+        self::assertCount(1, $crawler->filter("option[value='{$managedDomain->getId()}']"));
+        self::assertCount(0, $crawler->filter("option[value='{$unmanagedDomain->getId()}']"));
+    }
+
+    public function testDeletingUserRuleAlsoDeletesAliasRule(): void
+    {
+        $client = static::createClient();
+        $domain = DomainFactory::createOne();
+        $user = UserFactory::new()->user($domain)->create();
+        UserFactory::new()->user($domain)->create(['originalUser' => $user]);
+        $service = static::getContainer()->get(SenderRuleService::class);
+        self::assertTrue($service->createOrUpdateForUserAndAliases(
+            'sender@example.org',
+            $user,
+            'accept',
+            SenderRule::TYPE_USER,
+        ));
+        $ruleAddress = $this->getRuleAddressRepository()->findOneBy(['email' => 'sender@example.org']);
+        self::assertNotNull($ruleAddress);
+        $senderRuleRepository = static::getContainer()->get(SenderRuleRepository::class);
+        self::assertSame(2, $senderRuleRepository->count([
+            'sid' => $ruleAddress,
+            'priority' => SenderRule::PRIORITY_USER,
+        ]));
+
+        $client->loginUser($user);
+        $crawler = $client->request(Request::METHOD_GET, '/rules/W');
+        $client->click($crawler->filter('a.confirmModal')->link());
+
+        self::assertResponseRedirects();
+        self::assertSame(0, $senderRuleRepository->count([
+            'sid' => $ruleAddress,
+            'priority' => SenderRule::PRIORITY_USER,
+        ]));
+    }
+
+    private function getSenderRule(object $recipient, string $address): SenderRule
+    {
+        $ruleAddress = $this->getRuleAddressRepository()->findOneBy(['email' => $address]);
+        self::assertInstanceOf(RuleAddress::class, $ruleAddress);
+
+        $senderRuleRepository = static::getContainer()->get(SenderRuleRepository::class);
+        $senderRule = $senderRuleRepository->findOneBy([
+            'rid' => $recipient,
+            'sid' => $ruleAddress,
+        ]);
+        self::assertInstanceOf(SenderRule::class, $senderRule);
+
+        return $senderRule;
+    }
+
+    private function getRuleAddressRepository(): RuleAddressRepository
+    {
+        return static::getContainer()->get(RuleAddressRepository::class);
+    }
+
+    private function getCsrfToken(KernelBrowser $client, string $path): string
+    {
+        $crawler = $client->request(Request::METHOD_GET, $path);
+        $token = $crawler->filter('input[name="sender_rule[_token]"]')->attr('value');
+        self::assertNotNull($token);
+
+        return $token;
+    }
+}

--- a/app/tests/Service/SenderAddressSanitizerTest.php
+++ b/app/tests/Service/SenderAddressSanitizerTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Tests\Service;
+
+use App\Service\SenderAddressSanitizer;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class SenderAddressSanitizerTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{string, ?string}>
+     */
+    public static function provideAddresses(): iterable
+    {
+        yield 'email' => ['sender@example.org', 'sender@example.org'];
+        yield 'trimmed email' => ['  sender@example.org  ', 'sender@example.org'];
+        yield 'uppercase email' => ['Sender@Example.ORG', 'sender@example.org'];
+        yield 'domain' => ['example.org', '@example.org'];
+        yield 'prefixed domain' => ['@example.org', '@example.org'];
+        yield 'uppercase domain' => ['Example.ORG', '@example.org'];
+        yield 'empty value' => ['', null];
+        yield 'invalid value' => ['not an address', null];
+    }
+
+    #[DataProvider('provideAddresses')]
+    public function testSanitize(string $value, ?string $expected): void
+    {
+        $sanitizer = new SenderAddressSanitizer();
+
+        self::assertSame($expected, $sanitizer->sanitize($value));
+    }
+}

--- a/app/tests/Service/SenderRuleServiceTest.php
+++ b/app/tests/Service/SenderRuleServiceTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace App\Tests\Service;
+
+use App\Entity\RuleAddress;
+use App\Entity\SenderRule;
+use App\Repository\RuleAddressRepository;
+use App\Repository\SenderRuleRepository;
+use App\Service\SenderRuleService;
+use App\Tests\Factory\DomainFactory;
+use App\Tests\Factory\UserFactory;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+class SenderRuleServiceTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    public function testImportFileUsesSharedRuleCreation(): void
+    {
+        self::bootKernel();
+        $domain = DomainFactory::createOne();
+        $domainUser = UserFactory::createOne([
+            'domain' => $domain,
+            'email' => '@' . $domain->getDomain(),
+        ]);
+        $path = tempnam(sys_get_temp_dir(), 'sender-rules-test-');
+        self::assertIsString($path);
+        file_put_contents($path, "sender@example.org\nexample.net\ninvalid value\nsender@example.org\n");
+
+        try {
+            $service = static::getContainer()->get(SenderRuleService::class);
+            $service->importFile($path, $domain, 'accept');
+        } finally {
+            unlink($path);
+        }
+
+        $ruleAddressRepository = static::getContainer()->get(RuleAddressRepository::class);
+        $senderRuleRepository = static::getContainer()->get(SenderRuleRepository::class);
+
+        foreach (['sender@example.org' => 6, '@example.net' => 5] as $address => $priority) {
+            $ruleAddress = $ruleAddressRepository->findOneBy(['email' => $address]);
+            self::assertNotNull($ruleAddress);
+            self::assertSame($priority, $ruleAddress->getPriority());
+
+            $senderRule = $senderRuleRepository->findOneBy([
+                'rid' => $domainUser,
+                'sid' => $ruleAddress,
+            ]);
+            self::assertNotNull($senderRule);
+            self::assertSame('accept', $senderRule->getWbRule());
+            self::assertSame(SenderRule::TYPE_IMPORT, $senderRule->getType());
+        }
+
+        self::assertSame(2, $ruleAddressRepository->count([]));
+        self::assertSame(2, $senderRuleRepository->count([]));
+    }
+
+    public function testUserRuleDoesNotReplaceGroupRule(): void
+    {
+        self::bootKernel();
+        $user = UserFactory::new()->user()->create();
+        $ruleAddress = (new RuleAddress())
+            ->setEmail('sender@example.org')
+            ->setPriority(6);
+        $groupRule = (new SenderRule($user, $ruleAddress))
+            ->setWbRule('block')
+            ->setType(SenderRule::TYPE_GROUP)
+            ->setPriority(SenderRule::PRIORITY_GROUP_OVERRIDE);
+        $entityManager = static::getContainer()->get('doctrine.orm.entity_manager');
+        $entityManager->persist($ruleAddress);
+        $entityManager->persist($groupRule);
+        $entityManager->flush();
+
+        $service = static::getContainer()->get(SenderRuleService::class);
+        self::assertTrue($service->createOrUpdateForUserAndAliases(
+            'sender@example.org',
+            $user,
+            'accept',
+            SenderRule::TYPE_USER,
+        ));
+
+        $senderRuleRepository = static::getContainer()->get(SenderRuleRepository::class);
+        $userRule = $senderRuleRepository->findOneBy([
+            'rid' => $user,
+            'sid' => $ruleAddress,
+            'priority' => SenderRule::PRIORITY_USER,
+        ]);
+        self::assertNotNull($userRule);
+        self::assertSame('accept', $userRule->getWbRule());
+        self::assertSame('block', $groupRule->getWbRule());
+        self::assertSame(SenderRule::TYPE_GROUP, $groupRule->getType());
+        self::assertSame(SenderRule::PRIORITY_GROUP_OVERRIDE, $groupRule->getPriority());
+    }
+
+    public function testUserRuleIsCreatedForMainUserAndAliases(): void
+    {
+        self::bootKernel();
+        $domain = DomainFactory::createOne();
+        $mainUser = UserFactory::new()->user($domain)->create();
+        $alias = UserFactory::new()->user($domain)->create(['originalUser' => $mainUser]);
+        self::assertSame($mainUser, $alias->getMainUser());
+
+        $service = static::getContainer()->get(SenderRuleService::class);
+        self::assertTrue($service->createOrUpdateForUserAndAliases(
+            'sender@example.org',
+            $alias,
+            'block',
+            SenderRule::TYPE_USER,
+        ));
+
+        $ruleAddress = static::getContainer()->get(RuleAddressRepository::class)->findOneBy([
+            'email' => 'sender@example.org',
+        ]);
+        self::assertNotNull($ruleAddress);
+        $senderRuleRepository = static::getContainer()->get(SenderRuleRepository::class);
+
+        foreach ([$mainUser, $alias] as $recipient) {
+            self::assertNotNull($senderRuleRepository->findOneBy([
+                'rid' => $recipient,
+                'sid' => $ruleAddress,
+                'priority' => SenderRule::PRIORITY_USER,
+            ]));
+        }
+    }
+}

--- a/app/tests/Service/SenderRuleServiceTest.php
+++ b/app/tests/Service/SenderRuleServiceTest.php
@@ -8,6 +8,8 @@ use App\Repository\RuleAddressRepository;
 use App\Repository\SenderRuleRepository;
 use App\Service\SenderRuleService;
 use App\Tests\Factory\DomainFactory;
+use App\Tests\Factory\RuleAddressFactory;
+use App\Tests\Factory\SenderRuleFactory;
 use App\Tests\Factory\UserFactory;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Zenstruck\Foundry\Test\Factories;
@@ -21,11 +23,8 @@ class SenderRuleServiceTest extends KernelTestCase
     public function testImportFileUsesSharedRuleCreation(): void
     {
         self::bootKernel();
-        $domain = DomainFactory::createOne();
-        $domainUser = UserFactory::createOne([
-            'domain' => $domain,
-            'email' => '@' . $domain->getDomain(),
-        ]);
+        $domain = DomainFactory::new()->create();
+        $domainUser = UserFactory::findBy(['email' => '@' . $domain]);
         $path = tempnam(sys_get_temp_dir(), 'sender-rules-test-');
         self::assertIsString($path);
         file_put_contents($path, "sender@example.org\nexample.net\ninvalid value\nsender@example.org\n");
@@ -46,16 +45,18 @@ class SenderRuleServiceTest extends KernelTestCase
             self::assertSame($priority, $ruleAddress->getPriority());
 
             $senderRule = $senderRuleRepository->findOneBy([
-                'rid' => $domainUser,
-                'sid' => $ruleAddress,
+                'user' => $domainUser,
+                'senderRuleAddress' => $ruleAddress,
             ]);
             self::assertNotNull($senderRule);
             self::assertSame('accept', $senderRule->getWbRule());
             self::assertSame(SenderRule::TYPE_IMPORT, $senderRule->getType());
         }
 
-        self::assertSame(2, $ruleAddressRepository->count([]));
-        self::assertSame(2, $senderRuleRepository->count([]));
+        // At domain creation, it needs to have a root '@.' RuleAddress (shared accross all domains).
+        // Creating a domain also creates a SenderRule using this RuleAddress.
+        self::assertSame(3, RuleAddressFactory::count());
+        self::assertSame(3, SenderRuleFactory::count());
     }
 
     public function testUserRuleDoesNotReplaceGroupRule(): void
@@ -84,8 +85,8 @@ class SenderRuleServiceTest extends KernelTestCase
 
         $senderRuleRepository = static::getContainer()->get(SenderRuleRepository::class);
         $userRule = $senderRuleRepository->findOneBy([
-            'rid' => $user,
-            'sid' => $ruleAddress,
+            'user' => $user,
+            'senderRuleAddress' => $ruleAddress,
             'priority' => SenderRule::PRIORITY_USER,
         ]);
         self::assertNotNull($userRule);
@@ -119,8 +120,8 @@ class SenderRuleServiceTest extends KernelTestCase
 
         foreach ([$mainUser, $alias] as $recipient) {
             self::assertNotNull($senderRuleRepository->findOneBy([
-                'rid' => $recipient,
-                'sid' => $ruleAddress,
+                'user' => $recipient,
+                'senderRuleAddress' => $ruleAddress,
                 'priority' => SenderRule::PRIORITY_USER,
             ]));
         }

--- a/app/translations/messages+intl-icu.en.yaml
+++ b/app/translations/messages+intl-icu.en.yaml
@@ -236,6 +236,8 @@ Entities.Report.title: 'Activity report'
 Entities.Report.titleDay: 'On the last 24 hours'
 Entities.Report.titleMonth: 'Last month'
 Entities.Report.typeMessage: Type
+Entities.SenderRule.actions.addSenderB: 'Ban a sender'
+Entities.SenderRule.actions.addSenderW: 'Authorize a sender'
 Entities.SenderRule.actions.deleteSenderB: 'Unlock the sender'
 Entities.SenderRule.actions.deleteSenderW: 'Delete sender'
 Entities.SenderRule.fields.domain: Domain

--- a/app/translations/messages+intl-icu.fr.yaml
+++ b/app/translations/messages+intl-icu.fr.yaml
@@ -236,6 +236,8 @@ Entities.Report.title: "Rapport d'activité"
 Entities.Report.titleDay: 'Sur les dernières 24h'
 Entities.Report.titleMonth: 'Sur le dernier mois'
 Entities.Report.typeMessage: Type
+Entities.SenderRule.actions.addSenderB: 'Bannir un expéditeur'
+Entities.SenderRule.actions.addSenderW: 'Autoriser un expéditeur'
 Entities.SenderRule.actions.deleteSenderB: "Débloquer l'expéditeur"
 Entities.SenderRule.actions.deleteSenderW: "Supprimer l'expéditeur"
 Entities.SenderRule.fields.domain: Domaine

--- a/app/translations/validators.en.yaml
+++ b/app/translations/validators.en.yaml
@@ -1,1 +1,2 @@
 Error: Error
+sender_address.invalid: 'Enter a valid email address or domain.'

--- a/app/translations/validators.fr.yaml
+++ b/app/translations/validators.fr.yaml
@@ -1,1 +1,2 @@
 Error: Erreur
+sender_address.invalid: "Saisissez une adresse email ou un domaine valide."


### PR DESCRIPTION
## Related issue(s)
#125 

## How to test manually
Automatic tests added.

On "Blocked senders" and "Allowed senders", a button "Ban/Authorize a sender" was added.
When clicked, it open a modal and let you ban or authorize a sender. If you are an admin, you can choose on witch domain you'll ban it.
Then, you can check the rules on db and try sending mails through agentJ 

## Reviewer checklist

- [ ] Code is manually tested
- [ ] Interface works on both mobiles and big screens
- [ ] Interface works on both Firefox and Chrome
- [ ] Tests are up to date
- [ ] Documentation is up to date
- [ ] Pull request has been reviewed and approved
