### PR TITLE
Domain creation: remove DKIM popup

### DIFF
--- a/app/src/Controller/DomainController.php
+++ b/app/src/Controller/DomainController.php
@@ -437,7 +437,6 @@ class DomainController extends AbstractController
             $dkim->setPublicKey($pubkeyPem);
             // $public_key = openssl_pkey_get_public($public_key_pem);
 
-            $this->addFlash('info', $domain->getSrvSmtp() . ' DKIM public key: ' . $dkim->getDnsEntry());
             return true;
         } catch (ProcessFailedException $exception) {
             $this->addFlash('error', $exception->getMessage());


### PR DESCRIPTION
## Problem

The DKIM public key was shown via a flash message ("popup") when creating or editing a domain, but this key is now permanently displayed in the DNS card on the domain edit page. The popup is redundant.

## Fix

Removed the `addFlash('info', ...)` call in `DomainController::generateOpenDkim()` that duplicated the DKIM key already visible in the domain edit page's DNS section.

Closes #121