### PR TITLE
Use the current domain name for the 'noreply' email address

### DIFF
--- a/app/config/packages/twig.yaml
+++ b/app/config/packages/twig.yaml
@@ -7,7 +7,6 @@ twig:
           - 'forms/form_layout.html.twig'
     globals:
         agentjVersion: '%app.agentj-version%'
-        domain_mail_authentification_sender: '%app.domain_mail_authentification_sender%'
         oauth_enabled: '%env(bool:ENABLE_OAUTH)%'
         oauth_login_label: '%env(OAUTH_LOGIN_LABEL)%'
         azure_oauth_enabled: '%env(bool:ENABLE_AZURE_OAUTH)%'

--- a/app/config/services.yaml
+++ b/app/config/services.yaml
@@ -20,7 +20,6 @@ parameters:
     app.domain_default_spam_level: "%env(DOMAIN_DEFAULT_SPAM_LEVEL)%"
     app.domain_min_spam_level: "%env(DOMAIN_MIN_SPAM_LEVEL)%"
     app.domain_max_spam_level: "%env(DOMAIN_MAX_SPAM_LEVEL)%"
-    app.domain_mail_authentification_sender: "%env(SMTP_FROM)%"
     app.per_page_global: "25"
     timezone: "%env(TIMEZONE)%"
 

--- a/app/src/Command/SendAuthMailRequestCommand.php
+++ b/app/src/Command/SendAuthMailRequestCommand.php
@@ -43,8 +43,6 @@ class SendAuthMailRequestCommand
         private LockFactory $lockFactory,
         #[Autowire(param: 'app.amavisd-release')]
         public readonly string $amavisdRelease,
-        #[Autowire(param: 'app.domain_mail_authentification_sender')]
-        public readonly string $defaultSenderAdress,
     ) {
     }
 
@@ -141,7 +139,7 @@ class SendAuthMailRequestCommand
                 // "From" header and to use his locale when building the email.
                 $recipientUser = $recipientUsers[0];
 
-                $mailFrom = $this->getMailFrom($domain);
+                $mailFrom = $domain->getMailAuthenticationSender();
                 $fromName = $recipientUser->getFullName();
                 $locale = $this->localeService->getUserLocale($recipientUser);
 
@@ -296,20 +294,5 @@ class SendAuthMailRequestCommand
             $this->messageRepository->save($message);
             return false;
         }
-    }
-
-    private function getMailFrom(Domain $domain): string
-    {
-        if ($domain->getMailAuthenticationSender()) {
-            try {
-                $mailFrom = Address::create($domain->getMailAuthenticationSender())->getAddress();
-            } catch (\InvalidArgumentException $e) {
-                $mailFrom = $this->defaultSenderAdress;
-            }
-        } else {
-            $mailFrom = $this->defaultSenderAdress;
-        }
-
-        return $mailFrom;
     }
 }

--- a/app/src/Command/SendReportMailCommand.php
+++ b/app/src/Command/SendReportMailCommand.php
@@ -14,7 +14,6 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
@@ -33,8 +32,6 @@ class SendReportMailCommand extends Command
         private ManagerRegistry $doctrine,
         private TranslatorInterface $translator,
         private MailerInterface $mailer,
-        #[Autowire(param: 'app.domain_mail_authentification_sender')]
-        private string $defaultMailFrom,
         private MessageRecipientSearchRepository $messageRecipientSearchRepository,
         private MessageService $messageService,
         private UrlGeneratorInterface $urlGenerator,
@@ -75,9 +72,6 @@ class SendReportMailCommand extends Command
 
             $domain = $user->getDomain();
             $from = $domain->getMailAuthenticationSender();
-            if (!$from) {
-                $from = $this->defaultMailFrom;
-            }
 
             $locale = $this->localeService->getUserLocale($user);
             $fromName = $this->translator->trans('Entities.Report.mailFromName', locale: $locale);

--- a/app/src/Controller/DomainController.php
+++ b/app/src/Controller/DomainController.php
@@ -115,6 +115,7 @@ class DomainController extends AbstractController
 
         if ($form->isSubmitted() && $form->isValid()) {
             $domain->setCalculatedTransport();
+
             //Default messages
             //captcha page
             $messageConfig = $settingRepository->findBy(['context' => 'default_domain_messages']);

--- a/app/src/Entity/Domain.php
+++ b/app/src/Entity/Domain.php
@@ -410,9 +410,19 @@ class Domain
         return $this;
     }
 
-    public function getMailAuthenticationSender(): ?string
+    public function getMailAuthenticationSender(): string
     {
-        return $this->mailAuthenticationSender;
+        return $this->mailAuthenticationSender ?: $this->getDefaultMailAuthenticationSender();
+    }
+
+    /**
+     * Default "no-reply" address used when no custom sender is set on the
+     * domain, based on the domain itself rather than some unrelated default,
+     * whose DKIM key wouldn't match this domain.
+     */
+    public function getDefaultMailAuthenticationSender(): string
+    {
+        return 'no-reply@' . $this->domain;
     }
 
     public function setMailAuthenticationSender(?string $mailAuthenticationSender): self

--- a/app/src/MessageHandler/CreateAlertMessageHandler.php
+++ b/app/src/MessageHandler/CreateAlertMessageHandler.php
@@ -14,7 +14,6 @@ use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Mime\Email;
-use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
@@ -23,21 +22,18 @@ class CreateAlertMessageHandler
 {
     private EntityManagerInterface $entityManager;
     private ConsoleOutput $output;
-    private string $defaultMailFrom;
     private TranslatorInterface $translator;
     private MailerInterface $mailer;
     private LocaleService $localeService;
 
     public function __construct(
         EntityManagerInterface $entityManager,
-        ParameterBagInterface $params,
         TranslatorInterface $translator,
         MailerInterface $mailer,
         LocaleService $localeService,
     ) {
         $this->entityManager = $entityManager;
         $this->output = new ConsoleOutput();
-        $this->defaultMailFrom = $params->get('app.domain_mail_authentification_sender');
         $this->translator = $translator;
         $this->mailer = $mailer;
         $this->localeService = $localeService;
@@ -123,9 +119,6 @@ class CreateAlertMessageHandler
                         $emailAddress = $user->getEmail();
                         if ($emailAddress !== null && $user->getDomain() !== null) {
                             $mailFrom = $user->getDomain()->getMailAuthenticationSender();
-                            if (!$mailFrom || !filter_var($mailFrom, FILTER_VALIDATE_EMAIL)) {
-                                $mailFrom = $this->defaultMailFrom;
-                            }
 
                             $subject = $this->translator->trans(
                                 'Entities.Alert.messages.admin.virus.title',
@@ -185,9 +178,6 @@ class CreateAlertMessageHandler
                             $this->output->writeln('Mail alerts disabled for user: ' . $senderUser->getId());
                         } else {
                             $mailFrom = $senderUser->getDomain()->getMailAuthenticationSender();
-                            if (!$mailFrom || !filter_var($mailFrom, FILTER_VALIDATE_EMAIL)) {
-                                $mailFrom = $this->defaultMailFrom;
-                            }
 
                             $subject = $this->translator->trans(
                                 'Entities.Alert.messages.user.virus.title',
@@ -301,9 +291,6 @@ class CreateAlertMessageHandler
                     $emailAddress = $user->getEmail();
                     if ($emailAddress !== null && $user->getDomain() !== null) {
                         $mailFrom = $user->getDomain()->getMailAuthenticationSender();
-                        if (!$mailFrom || !filter_var($mailFrom, FILTER_VALIDATE_EMAIL)) {
-                            $mailFrom = $this->defaultMailFrom;
-                        }
 
                         $subject = $this->translator->trans(
                             'Entities.Alert.messages.admin.quota.title',
@@ -368,9 +355,7 @@ class CreateAlertMessageHandler
                                 $this->output->writeln('Mail alerts disabled for user: ' . $senderUser->getId());
                             } else {
                                 $mailFrom = $senderUser->getDomain()->getMailAuthenticationSender();
-                                if (!$mailFrom || !filter_var($mailFrom, FILTER_VALIDATE_EMAIL)) {
-                                    $mailFrom = $this->defaultMailFrom;
-                                }
+
                                 $subject = $this->translator->trans(
                                     'Entities.Alert.messages.user.quota.title',
                                     locale: $locale,

--- a/app/templates/domain/_form.html.twig
+++ b/app/templates/domain/_form.html.twig
@@ -346,7 +346,9 @@
             <div class="form-group">
                 <label for="domain_mailAuthenticationSender" class="col-form-label col-sm-12">
                     {{ 'Entities.Domain.fields.mailAuthenticationSender'|trans }}
-                    ({{ 'Generics.labels.byDefault'|trans }} : {{ domain_mail_authentification_sender }})
+                    {% if domain.id %}
+                        ({{ 'Generics.labels.byDefault'|trans }} : {{ domain.defaultMailAuthenticationSender }})
+                    {% endif %}
                 </label>
                 {{ form_widget(form.mailAuthenticationSender) }}
             </div>


### PR DESCRIPTION
## Problem

When `mailAuthenticationSender` is left empty on domain creation, auth requests, alerts and reports fall back to `app.domain_mail_authentification_sender` (`SMTP_FROM`), which is the AgentJ web domain's no-reply address. That domain rarely has a matching DKIM key (DKIM is only generated for domains managed in AgentJ), so these emails end up with an invalid DKIM signature.

## Fix

As discussed in the issue thread, this scopes the remaining work down to: default the domain's mail sender to the domain itself instead of the AgentJ web domain.

When `mailAuthenticationSender` is left blank on domain creation, it is now defaulted to `no-reply@<domain>` instead of staying empty (which previously fell back to the web domain's address at send time in `SendAuthMailRequestCommand`, `SendReportMailCommand` and `CreateAlertMessageHandler`).

Closes #111