### PR TITLE
Allow to switch to other "original user" shared mailboxes when opening a shared mailbox

### DIFF
--- a/app/src/Controller/MenuController.php
+++ b/app/src/Controller/MenuController.php
@@ -15,10 +15,8 @@ class MenuController extends AbstractController
 
         $domain = $user->getDomain();
 
-        $sharedBoxes = $user->getOwnedSharedBoxes();
         return $this->render('header.html.twig', [
             'domain' => $domain,
-            'sharedBoxes' => $sharedBoxes,
         ]);
     }
 }

--- a/app/src/Twig/AppExtension.php
+++ b/app/src/Twig/AppExtension.php
@@ -118,7 +118,11 @@ class AppExtension extends AbstractExtension
             $originalUser = $originalToken->getUser();
 
             if ($originalUser instanceof User) {
-                return $originalUser;
+                // The user carried by the original token comes from the
+                // serialized session, not from Doctrine, so it isn't
+                // hydrated (its collections, e.g. ownedSharedBoxes, would
+                // appear empty). Reload it from the database.
+                return $this->em->getRepository(User::class)->find($originalUser->getId());
             }
         }
 

--- a/app/templates/header.html.twig
+++ b/app/templates/header.html.twig
@@ -61,13 +61,19 @@
                         <div class="dropdown-divider"></div>
                     {% endif %}
 
-                    {% if sharedBoxes|length > 0%}
+                    {% if originalUser %}
+                        {% set sharedUsers = originalUser.ownedSharedBoxes | filter(sharedUser => sharedUser.id != app.user.id) %}
+                    {% else %}
+                        {% set sharedUsers = app.user.ownedSharedBoxes %}
+                    {% endif %}
+
+                    {% if sharedUsers | length > 0 %}
                         <div class="dropdown-header">{{ 'Navigation.mailboxes.other' | trans }}</div>
 
-                        {% for sharedBox in sharedBoxes %}
-                            <a class="dropdown-item" href="{{ path('homepage', {'_switch_user': sharedBox.username}) }}" title="{{ 'Generics.actions.connectAs'|trans() ~ sharedBox.username}}">
+                        {% for sharedUser in sharedUsers %}
+                            <a class="dropdown-item" href="{{ path('homepage', {'_switch_user': sharedUser.username}) }}" title="{{ 'Generics.actions.connectAs'|trans() ~ sharedUser.username}}">
                                 <i class="fas fa-envelope"></i>
-                                {{ sharedBox.username }}
+                                {{ sharedUser.username }}
                             </a>
                         {% endfor %}
 

--- a/app/tests/Security/SwitchToUserVoterTest.php
+++ b/app/tests/Security/SwitchToUserVoterTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace App\Tests\Security;
+
+use App\Tests\Factory\DomainFactory;
+use App\Tests\Factory\UserFactory;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+class SwitchToUserVoterTest extends WebTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    public function testSuperAdminCanSwitchToAnyMailbox(): void
+    {
+        $client = static::createClient();
+        $superAdmin = UserFactory::new()->superAdmin()->create();
+        $userA = UserFactory::new()->user()->create();
+        $client->loginUser($superAdmin);
+
+        $client->request(Request::METHOD_GET, '/', ['_switch_user' => $userA->getUsername()]);
+        $this->assertResponseRedirects('/', 302);
+    }
+
+    public function testAdminCanSwitchToMailboxOfHisDomains(): void
+    {
+        $client = static::createClient();
+        $domain = DomainFactory::createOne();
+        $admin = UserFactory::new()->admin([$domain])->create();
+        $user = UserFactory::new()->user($domain)->create();
+        $client->loginUser($admin);
+
+        $client->request(Request::METHOD_GET, '/', ['_switch_user' => $user->getUsername()]);
+
+        $this->assertResponseRedirects('/', 302);
+    }
+
+    public function testAdminCannotSwitchToMailboxOfOtherDomains(): void
+    {
+        $client = static::createClient();
+        $adminDomain = DomainFactory::createOne();
+        $otherDomain = DomainFactory::createOne();
+        $admin = UserFactory::new()->admin([$adminDomain])->create();
+        $user = UserFactory::new()->user($otherDomain)->create();
+        $client->loginUser($admin);
+
+        $client->request(Request::METHOD_GET, '/', ['_switch_user' => $user->getUsername()]);
+
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testUserCanSwitchToAnotherSharedMailbox(): void
+    {
+        $client = static::createClient();
+        // userA has access to both userB and userC's shared mailboxes.
+        $userA = UserFactory::new()->user()->create();
+        $userB = UserFactory::new()->user()->create(['sharedWith' => [$userA]]);
+        $userC = UserFactory::new()->user()->create(['sharedWith' => [$userA]]);
+        $client->loginUser($userA);
+
+        // userA switches to userB's mailbox.
+        $client->request(Request::METHOD_GET, '/', ['_switch_user' => $userB->getUsername()]);
+        $this->assertResponseRedirects('/', 302);
+
+        // While impersonating userB, userA switches directly to userC's
+        // mailbox. userB has no access to userC on their own, but userA
+        // (the real, original user behind the impersonation) does, so the
+        // switch must be allowed.
+        $client->request(Request::METHOD_GET, '/', ['_switch_user' => $userC->getUsername()]);
+        $this->assertResponseRedirects('/', 302);
+    }
+
+    public function testUserCannotChainSwitchToAMailboxImpersonatedUserHasAccess(): void
+    {
+        $client = static::createClient();
+        $userA = UserFactory::new()->user()->create();
+        $userB = UserFactory::new()->user()->create(['sharedWith' => [$userA]]);
+        // userC is shared with userB but not userA. This case could be
+        // legitimate (being careful with priviledge escalation), but
+        // SwitchToUserVoter doesn't have access to the SwitchUserToken and so
+        // we cannot support this case. It would probably require a different
+        // system.
+        $userC = UserFactory::new()->user()->create(['sharedWith' => [$userB]]);
+        $client->loginUser($userA);
+
+        $client->request(Request::METHOD_GET, '/', ['_switch_user' => $userB->getUsername()]);
+        $this->assertResponseRedirects('/', 302);
+
+        $client->request(Request::METHOD_GET, '/', ['_switch_user' => $userC->getUsername()]);
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testUserCannotSwitchToAMailboxHeCannotAccess(): void
+    {
+        $client = static::createClient();
+        $userA = UserFactory::new()->user()->create();
+        $userB = UserFactory::new()->user()->create(['sharedWith' => []]);
+        $client->loginUser($userA);
+
+        $client->request(Request::METHOD_GET, '/', ['_switch_user' => $userB->getUsername()]);
+
+        $this->assertResponseStatusCodeSame(403);
+    }
+}


### PR DESCRIPTION
## Problem

`MenuController::renderHeader()` built the shared-boxes dropdown list from `$this->getUser()`, i.e. the currently impersonated user. Shared boxes never own other shared boxes themselves, so as soon as you opened one, the list became empty — forcing you to exit impersonation before switching to another shared box.

## Fix

As suggested in the issue, the shared-boxes list is now computed directly in `header.html.twig` from `get_original_user()` (falling back to `app.user` when not impersonating), instead of being passed from the controller. This way the list always reflects the boxes owned by the original user, regardless of which box is currently open.

Closes #562