### PR TITLE
Add a label to name different authorized SMTP server + rephrase the form

### DIFF
--- a/app/assets/controllers/add_ip_address_controller.js
+++ b/app/assets/controllers/add_ip_address_controller.js
@@ -15,13 +15,14 @@ export default class extends Controller {
         this.index++;
 
         let div = document.createElement('div');
+        div.classList.add('domain-relay-row');
         div.innerHTML = newForm;
 
         const deleteButton = document.createElement('button');
         deleteButton.type = 'button';
         deleteButton.classList.add('btn', 'btn-danger', 'col-sm-2');
 
-        deleteButton.innerText = Translator.trans('Message.Actions.Delete');
+        deleteButton.innerText = Translator.trans('Generics.actions.remove');
 
         deleteButton.setAttribute('data-action', 'click->add-ip-address#remove');
         div.appendChild(deleteButton);
@@ -48,7 +49,7 @@ export default class extends Controller {
 
             $("#dialog-confirm").dialog("open");
             input.value = '';
-        } 
+        }
 
         const allInputs = this.containerTarget.querySelectorAll('input');
 

--- a/app/assets/styles/css/agentj.css
+++ b/app/assets/styles/css/agentj.css
@@ -419,3 +419,21 @@ table thead tr th {
     pointer-events: none;
     opacity: 0.7;
 }
+
+/* Authorized outgoing servers rows (domain form): a dedicated class instead
+   of a pile of Bootstrap utilities, so the layout only needs to be edited
+   here instead of staying in sync between the Twig template and
+   add_ip_address_controller.js. */
+.domain-relay-row {
+    display: flex;
+    align-items: flex-end;
+    gap: 0.75rem;
+    background-color: #f8f9fa;
+    border-radius: 0.25rem;
+    padding: 1rem;
+    margin-bottom: 1rem;
+}
+
+.domain-relay-row .form-group {
+    margin-bottom: 0;
+}

--- a/app/templates/domain/_form.html.twig
+++ b/app/templates/domain/_form.html.twig
@@ -79,19 +79,18 @@
             <div class="card-body" data-controller="add-ip-address">
                 <div data-add-ip-address-target="container" id="domain-relays-container">
                     {% for domainRelay in form.domainRelays %}
-                        <div>
-                            {{ form_row(domainRelay.ipAddress, { attr: { class:'form-control col-sm-8', 'data-action': 'blur->add-ip-address#validateIp', style: "width: 50%"  } }) }}
+                        <div class="domain-relay-row">
+                            {{ form_row(domainRelay.ipAddress, { attr: { class:'form-control col-sm-8', 'data-action': 'blur->add-ip-address#validateIp' } }) }}
                             <button type="button" class="btn btn-danger col-sm-2"
-                                    data-action="click->add-ip-address#remove">{{ 'Generics.actions.delete' | trans() }}</button>
+                                    data-action="click->add-ip-address#remove">{{ 'Generics.actions.remove' | trans() }}</button>
                         </div>
                     {% endfor %}
                 </div>
 
                 {% set domainRelayPrototype %}
-                    <br>
-                    {{ form_row(form.domainRelays.vars.prototype.ipAddress, { attr: { class: 'domain-relay-item form-control col-sm-8' , 'data-action': 'blur->add-ip-address#validateIp', style: "width: 50%" } })|e }}
+                    {{ form_row(form.domainRelays.vars.prototype.ipAddress, { attr: { class: 'domain-relay-item form-control col-sm-8' , 'data-action': 'blur->add-ip-address#validateIp' } })|e }}
                     <button type="button" class="btn btn-danger col-sm-2"
-                            data-action="click->add-ip-address#remove">{{ 'Generics.actions.delete' | trans() }}</button>
+                            data-action="click->add-ip-address#remove">{{ 'Generics.actions.remove' | trans() }}</button>
                 {% endset %}
 
                 <div style="display: none;" data-add-ip-address-target="prototype" id="domain-relays-prototype"

--- a/app/translations/messages+intl-icu.en.yaml
+++ b/app/translations/messages+intl-icu.en.yaml
@@ -76,7 +76,7 @@ Entities.Domain.labels.dynamicsVariables.URL_MESSAGE_RESTORE: 'URL to recover th
 Entities.Domain.labels.dynamicsVariables.URL_MSGS: 'Link to pending emails'
 Entities.Domain.labels.dynamicsVariables.USERNAME: "User's name"
 Entities.Domain.labels.filters: 'FILTERS & RATES'
-Entities.Domain.labels.ipAddresses: 'IP address of the sending server'
+Entities.Domain.labels.ipAddresses: 'Authorized outgoing servers'
 Entities.Domain.labels.rules: Rules
 Entities.Domain.labels.saveBeforeConnectors: 'Please register the domain first before adding connectors.'
 Entities.DomainRelay.fields.ipAddress: 'IP address'
@@ -290,7 +290,7 @@ Entities.User.labels.defaultGroupSetting: 'Default group setting'
 Entities.User.labels.domainSetting: 'Domain setting'
 Form.Error: Error
 Form.ImportFile: 'Select a file to import'
-Generics.actions.addIpAddress: 'IP Address'
+Generics.actions.addIpAddress: 'Add a server'
 Generics.actions.backToPreviousPage: 'Back to the previous page'
 Generics.actions.backToTheList: 'Back to list'
 Generics.actions.cancel: Cancel
@@ -310,6 +310,7 @@ Generics.actions.impersonate: 'Sign in'
 Generics.actions.import: Import
 Generics.actions.importFile: 'Import from file'
 Generics.actions.rememberme: 'Remember me'
+Generics.actions.remove: Remove
 Generics.actions.save: Save
 Generics.actions.search: Search
 Generics.actions.showMore: 'Show more'

--- a/app/translations/messages+intl-icu.fr.yaml
+++ b/app/translations/messages+intl-icu.fr.yaml
@@ -76,7 +76,7 @@ Entities.Domain.labels.dynamicsVariables.URL_MESSAGE_RESTORE: 'URL récupérant 
 Entities.Domain.labels.dynamicsVariables.URL_MSGS: 'Lien vers les mails en attente'
 Entities.Domain.labels.dynamicsVariables.USERNAME: "Nom de l'utilisateur"
 Entities.Domain.labels.filters: 'FILTRES & QUOTAS'
-Entities.Domain.labels.ipAddresses: "IP du serveur d'envoi"
+Entities.Domain.labels.ipAddresses: 'Serveurs sortants autorisés'
 Entities.Domain.labels.rules: Règles
 Entities.Domain.labels.saveBeforeConnectors: "Veuillez d'abord enregistrer le domaine, pour ajouter des connecteurs."
 Entities.DomainRelay.fields.ipAddress: 'Adresse IP'
@@ -290,7 +290,7 @@ Entities.User.labels.defaultGroupSetting: 'Paramètre du groupe par défaut'
 Entities.User.labels.domainSetting: 'Paramètre du domaine'
 Form.Error: Erreur
 Form.ImportFile: 'Sélectionnez un fichier à importer'
-Generics.actions.addIpAddress: 'Ajouter une adresse IP'
+Generics.actions.addIpAddress: 'Ajouter un serveur'
 Generics.actions.backToPreviousPage: 'Retour à la page précédente'
 Generics.actions.backToTheList: 'Retour à la liste'
 Generics.actions.cancel: Annuler
@@ -310,6 +310,7 @@ Generics.actions.impersonate: 'Se connecter'
 Generics.actions.import: Importer
 Generics.actions.importFile: 'Importer depuis un fichier'
 Generics.actions.rememberme: 'Se souvenir de moi'
+Generics.actions.remove: Retirer
 Generics.actions.save: Enregistrer
 Generics.actions.search: Rechercher
 Generics.actions.showMore: 'Voir plus'


### PR DESCRIPTION
## Problem

Per the discussion on the issue, the "authorized outgoing servers" form (domain edit page) needed clearer wording and better visual grouping.

## Fix

- Card title: "IP address of the sending server" → **"Authorized outgoing servers"**
- "add" button → **"Add a server"**
- "delete" button → **"Remove"** (new dedicated translation key `Generics.actions.removeServer`; the old buttons reused `Generics.actions.delete` / `Message.Actions.Delete`, both shared with unrelated delete buttons elsewhere in the app, so they couldn't just be renamed in place)
- Each server row (both the ones rendered server-side and the ones added dynamically via the Stimulus controller) is now wrapped in a light, rounded, padded box so the label/field/button read as one group, matching the mockup posted in the issue.

Closes #115