### PR TITLE
fix: human authentication is not sent to mailing lists

### DIFF
--- a/app/templates/message/show.html.twig
+++ b/app/templates/message/show.html.twig
@@ -32,7 +32,7 @@
             {{ messageRecipient.bspamLevel }}
         </div>
 
-        {% if message.sendCaptcha > 0 %}
+        {% if message.sendCaptcha > 0 and not message.isMlist %}
             <div class="col-md-4">
                 {{ 'Entities.Message.dateAuthRequestAt' | trans }}
                 :

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -163,6 +163,32 @@ then
 	send 'in_pass_known' 'in' 'user@laissepasser.fr' 1
 fi
 
+if [ -z "$1" ] || [ "$1" = "mllist" ]
+then
+	echo "---- mailing list is not filtered ----" 1>&2
+	{ sleep 5 && $dx php bin/console agentj:send-auth-mail-token >/dev/null; } &
+	to_addr="news@liste.domaine.fr"
+    expected_sender="news@liste.domaine.fr"
+	send 'in_pass_mailing_list' 'in' 'user@blocnormal.fr' 0 1 '--add-header=List-Id:<news.liste.domaine.fr>'
+
+    # Check that user@blocnormal.fr did not received newsletter mail
+    sleep 5
+    mail_count=$($curl "$mailpit_api/search?query=to:user@blocnormal.fr%20subject:\"$message_subject\"" \
+      | jq '.messages_count')
+    if [ "$mail_count" -ne 0 ]; then
+        # user@blocknormal.fr should not receive email as news@liste.domaine.fr is not allowed
+        echo "unexpected mail for user@blocnormal.fr not found"
+        exit 1
+    fi
+
+    # Check that the newsletter address did not receive human auth mail
+    mail_count=$($curl "$mailpit_api/search?query=to:news@liste.domaine.fr" | jq '.messages_count')
+    if [ "$mail_count" -ne 0 ]; then
+        echo "unexpected mail sent to news@liste.domaine.fr"
+        exit 1
+    fi
+fi
+
 if [ -z "$1" ] || [ "$1" = "virusspam" ]
 then
 	echo "---- virus/spam ----" 1>&2


### PR DESCRIPTION
## Related issue(s)
<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->
#510 

## How to test manually
<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->
- simulate a mailing list mail
```
swaks \
  --from news@domaine.fr \
  --to user@blocnormal.fr \
  --server 172.28.2.5:26 \
  --h-Subject="test_is_mailing_list_15455" \
  --body "in_pass_mailing_list from: news@liste.domaine.fr to: user@blocnormal.fr via: 172.28.2.5:26" \
  --add-header "List-Id: news.liste.domaine.fr"
```
- check that no human auth mail is sent (see in mailpit)

## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [ ] Code is manually tested
- [ ] Interface works on both mobiles and big screens
- [ ] Interface works on both Firefox and Chrome
- [ ] Tests are up to date
- [ ] Documentation is up to date
- [ ] Pull request has been reviewed and approved
