### PR TITLE
feat: change from bypassHumanAuth to humanAuthenticationEnabled

### DIFF
--- a/app/migrations/Version20260806134156.php
+++ b/app/migrations/Version20260806134156.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260806134156 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Rename user.bypass_human_auth to human_authentication_enabled_at and '
+            . 'connector.bypass_human_auth to human_authentication_enabled_at';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // Users => change bool bypass_human_auth to datetime human_authentication_enabled_at
+        $this->addSql('ALTER TABLE users ADD human_authentication_enabled_at DATETIME DEFAULT CURRENT_TIMESTAMP');
+        $this->addSql(<<<SQL
+            UPDATE users SET human_authentication_enabled_at = NULL WHERE bypass_human_auth = 1;
+        SQL);
+        $this->addSql('ALTER TABLE users DROP bypass_human_auth');
+
+        // LdapConnector => rename ldap_bypass_human_auth to ldap_human_authentication_enabled
+        $this->addSql(<<<SQL
+            ALTER TABLE connector RENAME COLUMN ldap_bypass_human_auth TO ldap_human_authentication_enabled;
+        SQL);
+        // LdapConnector => toggle value of ldap_human_authentication_enabled because of the rename
+        $this->addSql(<<<SQL
+            UPDATE connector SET ldap_human_authentication_enabled = NOT ldap_human_authentication_enabled;
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        // Users =>  restore bool bypass_human_auth
+        $this->addSql('ALTER TABLE users ADD bypass_human_auth BOOLEAN DEFAULT FALSE');
+        $this->addSql('UPDATE users SET bypass_human_auth = 1 WHERE human_authentication_enabled_at IS NULL');
+        $this->addSql('ALTER TABLE users DROP human_authentication_enabled_at');
+
+        // LdapConnector => rename ldap_human_authentication_enabled to ldap_bypass_human_auth
+        $this->addSql(<<<SQL
+            ALTER TABLE connector RENAME COLUMN ldap_human_authentication_enabled TO ldap_bypass_human_auth;
+        SQL);
+        // LdapConnector => toggle value of ldap_bypass_human_auth
+        // because of the rename of ldap_human_authentication_enabled
+        $this->addSql(<<<SQL
+            UPDATE connector SET ldap_bypass_human_auth = NOT ldap_bypass_human_auth;
+        SQL);
+    }
+}

--- a/app/src/Command/AmavisAutoReleaseCommand.php
+++ b/app/src/Command/AmavisAutoReleaseCommand.php
@@ -66,7 +66,7 @@ class AmavisAutoReleaseCommand extends Command
             $recipientDomain = $recipientUser->getDomain();
 
             $senderIsAuthorized = $this->senderRuleRepository->isSenderAuthorizedByRecipient($senderEmail, $recipient);
-            $humanAuthIsDisabled = $recipientUser->getBypassHumanAuth();
+            $humanAuthIsDisabled = !$recipientUser->isHumanAuthenticationEnabled();
 
             $spamLevel = $recipientDomain->getLevel();
             $authorizedSendersSpamLevel = $recipientDomain->getAuthorizedSendersSpamLevel();

--- a/app/src/Command/LdapImportCommand.php
+++ b/app/src/Command/LdapImportCommand.php
@@ -47,14 +47,14 @@ class LdapImportCommand extends Command
         private TranslatorInterface $translator,
         private LdapService $ldapService,
         private UserService $userService,
-        private GroupService $groupService
+        private GroupService $groupService,
     ) {
         parent::__construct();
     }
 
     protected function configure(): void
     {
-        $this->addArgument('connectorId', InputArgument::REQUIRED, 'Connector from wich import users');
+        $this->addArgument('connectorId', InputArgument::REQUIRED, 'Connector from which import users');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -257,7 +257,7 @@ class LdapImportCommand extends Command
         $user->setDomain($domain);
         $user->setPriority(RuleAddressService::computePriority($emailAddress));
         $user->setRoles('["ROLE_USER"]');
-        $user->setBypassHumanAuth($this->connector->isLdapBypassHumanAuth());
+        $user->setHumanAuthenticationEnabled($this->connector->isLdapHumanAuthenticationEnabled());
         $user->setReport($this->connector->isLdapReport());
         $this->em->persist($user);
         $this->em->flush();

--- a/app/src/Entity/LdapConnector.php
+++ b/app/src/Entity/LdapConnector.php
@@ -61,8 +61,8 @@ class LdapConnector extends Connector
     #[ORM\Column(nullable: false, options: ['default' => true])]
     private bool $ldapAllowConnection = true;
 
-    #[ORM\Column(nullable: false, options: ['default' => false])]
-    private bool $ldapBypassHumanAuth = false;
+    #[ORM\Column(nullable: false, options: ['default' => true])]
+    private bool $ldapHumanAuthenticationEnabled = true;
 
     #[ORM\Column(nullable: false, options: ['default' => true])]
     private bool $ldapReport = true;
@@ -273,14 +273,14 @@ class LdapConnector extends Connector
         return $this;
     }
 
-    public function isLdapBypassHumanAuth(): bool
+    public function isLdapHumanAuthenticationEnabled(): bool
     {
-        return $this->ldapBypassHumanAuth;
+        return $this->ldapHumanAuthenticationEnabled;
     }
 
-    public function setLdapBypassHumanAuth(bool $ldapBypassHumanAuth): static
+    public function setLdapHumanAuthenticationEnabled(bool $isEnabled): static
     {
-        $this->ldapBypassHumanAuth = $ldapBypassHumanAuth;
+        $this->ldapHumanAuthenticationEnabled = $isEnabled;
 
         return $this;
     }

--- a/app/src/Entity/User.php
+++ b/app/src/Entity/User.php
@@ -3,6 +3,8 @@
 namespace App\Entity;
 
 use App\Repository\UserRepository;
+use DateTime;
+use DateTimeInterface;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Types\Types;
@@ -110,8 +112,8 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     #[ORM\Column(type: 'integer', nullable: true)]
     private ?int $dateLastReport;
 
-    #[ORM\Column(type: 'boolean', nullable: false, options: ['default' => false])]
-    private bool $bypassHumanAuth = false;
+    #[ORM\Column(type: 'datetime', nullable: true, options: ['default' => 'CURRENT_TIMESTAMP'])]
+    private ?DateTimeInterface $humanAuthenticationEnabledAt = null;
 
     #[ORM\Column(type: 'string', length: 5, nullable: true)]
     private ?string $preferedLang;
@@ -152,6 +154,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
         $this->groups = new ArrayCollection();
         $this->ownedSharedBoxes = new ArrayCollection();
         $this->senderRules = new ArrayCollection();
+        $this->setHumanAuthenticationEnabled(true);
     }
 
     public function __toString(): string
@@ -497,14 +500,14 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
         return $this;
     }
 
-    public function getBypassHumanAuth(): ?bool
+    public function getHumanAuthenticationEnabledAt(): ?DateTimeInterface
     {
-        return $this->bypassHumanAuth;
+        return $this->humanAuthenticationEnabledAt;
     }
 
-    public function setBypassHumanAuth(?bool $bypassHumanAuth): self
+    public function setHumanAuthenticationEnabledAt(?DateTimeInterface $date): self
     {
-        $this->bypassHumanAuth = $bypassHumanAuth;
+        $this->humanAuthenticationEnabledAt = $date;
 
         return $this;
     }
@@ -538,9 +541,17 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
         return $this->report;
     }
 
-    public function isBypassHumanAuth(): ?bool
+    public function isHumanAuthenticationEnabled(): bool
     {
-        return $this->bypassHumanAuth;
+        return $this->humanAuthenticationEnabledAt !== null;
+    }
+
+    public function setHumanAuthenticationEnabled(bool $isEnabled): self
+    {
+        $date = $isEnabled ? new DateTime() : null;
+        $this->setHumanAuthenticationEnabledAt($date);
+
+        return $this;
     }
 
     /**

--- a/app/src/Form/LdapConnectorType.php
+++ b/app/src/Form/LdapConnectorType.php
@@ -115,8 +115,8 @@ class LdapConnectorType extends ConnectorType
             ->add('ldapReport', null, [
                 'label' => new TranslatableMessage('Entities.LdapConnector.fields.report'),
             ])
-            ->add('ldapBypassHumanAuth', null, [
-                'label' => new TranslatableMessage('Entities.LdapConnector.fields.bypassHumanAuth'),
+            ->add('ldapHumanAuthenticationEnabled', null, [
+                'label' => new TranslatableMessage('Entities.LdapConnector.fields.activateHumanAuthentication'),
             ])
         ;
     }

--- a/app/src/Form/UserPreferencesType.php
+++ b/app/src/Form/UserPreferencesType.php
@@ -4,19 +4,24 @@ namespace App\Form;
 
 use App\Entity\User;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Translation\TranslatableMessage;
 
 class UserPreferencesType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
-            ->add('report', null, [
-                'label' => false,
+            ->add('report', CheckboxType::class, [
+                'label' => new TranslatableMessage('Entities.User.fields.report'),
+                'required' => false,
             ])
-            ->add('bypassHumanAuth', null, [
-                'label' => false,
+            ->add('humanAuthenticationEnabled', CheckboxType::class, [
+                'label' => new TranslatableMessage('Entities.User.fields.activateHumanAuthentication'),
+                'required' => false,
+                'property_path' => 'humanAuthenticationEnabled',
             ])
         ;
     }

--- a/app/templates/account/index.html.twig
+++ b/app/templates/account/index.html.twig
@@ -39,6 +39,7 @@
                     </a>
                 </li>
             </ul>
+
             <div class="tab-content p-3" id="accountTabContent">
                 <div class="tab-pane fade show active" id="account-infos" role="tabpanel" aria-labelledby="account-infos-tab">
                     {{ form_start(form) }}
@@ -49,29 +50,28 @@
                         <div class="col-md-10">
                             {{ app.user.fullName }}
                         </div>
+
                         <div class="col-md-2">
                             {{ 'Entities.User.fields.email'|trans() }}
                         </div>
                         <div class="col-md-10">
                             {{ app.user.email }}
                         </div>
+
                         <div class="col-md-2">
                             {{ 'Entities.User.fields.group'|trans() }}
                         </div>
                         <div class="col-md-10"></div>
-                        <div class="col-md-2">
-                            {{ 'Entities.User.fields.report'|trans() }}
+
+                        <div class="col-md-12">
+                            {{ form_row(form.report) }}
                         </div>
-                        <div class="col-md-10">
-                            {{ form_widget(form.report) }}
-                        </div>
-                        <div class="col-md-2">
-                            {{ 'Entities.User.fields.bypassHumanAuth'|trans() }}
-                        </div>
-                        <div class="col-md-10">
-                            {{ form_widget(form.bypassHumanAuth) }}
+
+                        <div class="col-md-12">
+                            {{ form_row(form.humanAuthenticationEnabled) }}
                         </div>
                     </div>
+
                     <div class="d-flex justify-content-center">
                         <input
                             type="submit"

--- a/app/templates/connector/_form_ldap.html.twig
+++ b/app/templates/connector/_form_ldap.html.twig
@@ -176,7 +176,7 @@
         <div class="row">
             <div class="col-md-12">
             <div class="form-group">
-                {{ form_widget(form.ldapBypassHumanAuth) }}
+                {{ form_widget(form.ldapHumanAuthenticationEnabled) }}
             </div>
             </div>
         </div>

--- a/app/translations/messages+intl-icu.en.yaml
+++ b/app/translations/messages+intl-icu.en.yaml
@@ -122,7 +122,7 @@ Entities.LdapConnector.fields.LdapBaseDN: 'Base DN'
 Entities.LdapConnector.fields.LdapPassword: Password
 Entities.LdapConnector.fields.advancedOptions: 'Advanced options'
 Entities.LdapConnector.fields.allowAnonymousBind: 'Anonymous connection'
-Entities.LdapConnector.fields.bypassHumanAuth: 'Deactivate human authentication for created users'
+Entities.LdapConnector.fields.activateHumanAuthentication: 'Activate human authentication for created users'
 Entities.LdapConnector.fields.connectionInformation: 'Connection information'
 Entities.LdapConnector.fields.ldapAliasField: 'LDAP field for alias (if different from email)'
 Entities.LdapConnector.fields.ldapAllowConnection: 'Allow LDAP authentication'
@@ -262,7 +262,7 @@ Entities.User.actions.add_new: 'New user'
 Entities.User.actions.add_new_alias: 'Add a new alias'
 Entities.User.actions.edit: 'Edition of a user'
 Entities.User.fields.alias: Alias
-Entities.User.fields.bypassHumanAuth: 'Deactivate human authentication'
+Entities.User.fields.activateHumanAuthentication: 'Activate human authentication'
 Entities.User.fields.domain: Domain
 Entities.User.fields.email: Email
 Entities.User.fields.emailRecovery: 'Recovery email'

--- a/app/translations/messages+intl-icu.fr.yaml
+++ b/app/translations/messages+intl-icu.fr.yaml
@@ -122,7 +122,7 @@ Entities.LdapConnector.fields.LdapBaseDN: 'Base DN'
 Entities.LdapConnector.fields.LdapPassword: 'Mot de passe'
 Entities.LdapConnector.fields.advancedOptions: 'Options avancées'
 Entities.LdapConnector.fields.allowAnonymousBind: 'Connexion anonyme'
-Entities.LdapConnector.fields.bypassHumanAuth: "Désactiver l'authentification humaine pour les utilisateurs créés"
+Entities.LdapConnector.fields.activateHumanAuthentication: "Activer l'authentification humaine pour les utilisateurs créés"
 Entities.LdapConnector.fields.connectionInformation: 'Informations de connexion'
 Entities.LdapConnector.fields.ldapAliasField: "Champ LDAP pour l'alias (si différent de l'email)"
 Entities.LdapConnector.fields.ldapAllowConnection: "Autoriser l'authentification par LDAP"
@@ -262,7 +262,7 @@ Entities.User.actions.add_new: 'Nouvel utilisateur'
 Entities.User.actions.add_new_alias: 'Ajouter un nouvel alias'
 Entities.User.actions.edit: "Edition d'un utilisateur"
 Entities.User.fields.alias: Alias
-Entities.User.fields.bypassHumanAuth: "Désactiver l'authentification humaine"
+Entities.User.fields.activateHumanAuthentication: "Activer l'authentification humaine"
 Entities.User.fields.domain: Domaine
 Entities.User.fields.email: Email
 Entities.User.fields.emailRecovery: 'Email de récupération'


### PR DESCRIPTION
* User => store activation date in humanAuthenticationEnabledAt
* LdapConnector => store activation in humanAuthenticationEnabled

## Related issue(s)
<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->
#555 

## How to test manually
<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->
* users:
  * edit a user and use `scripts/mail_to_agentj.sh` to check that new senders receive or not human auth mail
* LDAP connector:
  1. configure LDAP connector and set `Activate human authentication for created users` to false
    * import users and check that they have humanAuthenticationEnabledAt empty
  2. set `Activate human authentication for created users` to false
    * import users and check that they have humanAuthenticationEnabledAt is not empty
  

## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works on both Firefox and Chrome
- [x] Tests are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
