### PR TITLE
fix: restrict wblist imports to admins on 2.6

### DIFF
--- a/app/config/packages/security.yaml
+++ b/app/config/packages/security.yaml
@@ -63,4 +63,5 @@ security:
          - { path: ^/admin, roles: [ROLE_ADMIN] }
          - { path: ^/policy/, roles: ROLE_SUPER_ADMIN }
          - { path: ^/domain, roles: ROLE_ADMIN }
+         - { path: ^/wblist/admin, roles: ROLE_ADMIN }
          - { path: ^/, roles: ROLE_USER }


### PR DESCRIPTION
## Related issue(s)
#566 

## How to test manually
Try to post on /rules/admin/import/W on an account without ADMIN rights

## Reviewer checklist

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works on both Firefox and Chrome
- [x] Tests are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
