### PR TITLE
fix(message): truncate overly long sender display name in the message list

### DIFF
--- a/app/templates/message/index.html.twig
+++ b/app/templates/message/index.html.twig
@@ -131,7 +131,8 @@
                                                 @
                                                 {{ email.1 |replace({'>':''})}}
                                             {% else %}
-                                                {{ senderSplit|replace({'>':''}) }}
+                                                {% set cleanSplit = senderSplit|replace({'>':''}) %}
+                                                {{ cleanSplit|slice(0,35) }}{% if cleanSplit|length > 35 %}…{% endif %}
                                             {% endif %}
                                         {% endfor %}
                                     </span>


### PR DESCRIPTION
## Problem

In the message list (`table_msgs`), the *Sender* column can overflow badly when the message's `From` header carries a very long display name without an `@` in it, e.g.:

`"DHL /EXPRESS ADMINISTRATIVE GROUP (FYDIBOHF23SPDLT)/CN=RECIPIENTS/CN=B7A707497B564FD-43681" <ssssssss.ddddddd@ffffff.fr>`

The existing truncation logic in `message/index.html.twig` only wraps/splits the part that contains an `@` (the address). The display-name part, when longer than 35 characters and without an `@`, was printed in full, breaking the table layout.

## Fix

Truncate any non-address segment to 35 characters with an ellipsis (same threshold already used for the rest of the block), consistent with how the message subject column is already truncated elsewhere in this template. The full sender value is still available on hover via the existing `title` attribute.

## Testing

- `php bin/console lint:twig` passes on the modified template.
