### PR TITLE
chore: Revert making validate_captcha not nullable

### DIFF
--- a/app/migrations/Version20260601151122.php
+++ b/app/migrations/Version20260601151122.php
@@ -7,6 +7,16 @@ namespace DoctrineMigrations;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
 
+/**
+ * This migration has been commented in 2.7.1 as we realized too late that
+ * executing it would lock the database for too long on huge tables.
+ *
+ * As this change (changing validate_captcha from "NULL" to "NOT NULL") isn't
+ * really useful, we prefered to comment the SQL queries.
+ *
+ * This file is kept and another migration (Version20260814081035) is provided
+ * to revert the change for those who migrated to 2.7.0.
+ */
 final class Version20260601151122 extends AbstractMigration
 {
     public function getDescription(): string
@@ -16,15 +26,19 @@ final class Version20260601151122 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->addSql('UPDATE msgs SET validate_captcha = 0 WHERE validate_captcha IS NULL');
-        $this->addSql('UPDATE out_msgs SET validate_captcha = 0 WHERE validate_captcha IS NULL');
-        $this->addSql('ALTER TABLE msgs CHANGE validate_captcha validate_captcha INT UNSIGNED DEFAULT 0 NOT NULL');
-        $this->addSql('ALTER TABLE out_msgs CHANGE validate_captcha validate_captcha INT UNSIGNED DEFAULT 0 NOT NULL');
+        //$this->addSql('UPDATE msgs SET validate_captcha = 0 WHERE validate_captcha IS NULL');
+        //$this->addSql('UPDATE out_msgs SET validate_captcha = 0 WHERE validate_captcha IS NULL');
+        //$this->addSql(
+        //    'ALTER TABLE msgs CHANGE validate_captcha validate_captcha INT UNSIGNED DEFAULT 0 NOT NULL'
+        //);
+        //$this->addSql(
+        //    'ALTER TABLE out_msgs CHANGE validate_captcha validate_captcha INT UNSIGNED DEFAULT 0 NOT NULL'
+        //);
     }
 
     public function down(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE out_msgs CHANGE validate_captcha validate_captcha INT UNSIGNED DEFAULT 0');
-        $this->addSql('ALTER TABLE msgs CHANGE validate_captcha validate_captcha INT UNSIGNED DEFAULT 0');
+        //$this->addSql('ALTER TABLE out_msgs CHANGE validate_captcha validate_captcha INT UNSIGNED DEFAULT 0');
+        //$this->addSql('ALTER TABLE msgs CHANGE validate_captcha validate_captcha INT UNSIGNED DEFAULT 0');
     }
 }

--- a/app/migrations/Version20260814081035.php
+++ b/app/migrations/Version20260814081035.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * This migration reverts the changes from Version20260601151122 only for those
+ * who applied it in 2.7.0 (we cancelled it as it would take too much time on
+ * huge databases).
+ */
+final class Version20260814081035 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Revert msgs and out_msgs validate_captcha not nullable.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $isNullable = $this->connection->fetchOne(<<<SQL
+            SELECT IS_NULLABLE FROM information_schema.COLUMNS
+            WHERE TABLE_SCHEMA = DATABASE()
+            AND TABLE_NAME = 'msgs'
+            AND COLUMN_NAME = 'validate_captcha';
+            SQL);
+
+        $this->skipIf($isNullable === 'YES', 'msgs.validate_captcha is already nullable.');
+
+        $this->addSql('ALTER TABLE msgs CHANGE validate_captcha validate_captcha INT UNSIGNED DEFAULT 0');
+        $this->addSql('ALTER TABLE out_msgs CHANGE validate_captcha validate_captcha INT UNSIGNED DEFAULT 0');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE msgs CHANGE validate_captcha validate_captcha INT UNSIGNED DEFAULT 0 NOT NULL');
+        $this->addSql('ALTER TABLE out_msgs CHANGE validate_captcha validate_captcha INT UNSIGNED DEFAULT 0 NOT NULL');
+    }
+}

--- a/app/src/Entity/BaseMessage.php
+++ b/app/src/Entity/BaseMessage.php
@@ -79,9 +79,10 @@ class BaseMessage
     #[ORM\Column(
         name: 'validate_captcha',
         type: 'integer',
+        nullable: true,
         options: ['unsigned' => true, 'default' => 0],
     )]
-    private int $validateCaptcha;
+    private ?int $validateCaptcha = 0;
 
     #[ORM\Column(name: 'status_id', nullable: true)]
     private ?int $status;


### PR DESCRIPTION
## Related issue(s)
<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

N/A

## How to test manually
<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

- Run `make db-migrate`
- Using a database initialized in 2.7.0, verify that the last migration is not skipped
- Using a database initialized in 2.6.*, verify that the last migration is skipped

## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both mobiles and big screens
- [x] Interface works on both Firefox and Chrome
- [x] Tests are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
