### PR TITLE
fix: set users.local='Y' at mailbox creation (#537)

### DIFF
--- a/app/migrations/Version20260824090000.php
+++ b/app/migrations/Version20260824090000.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260824090000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Backfill users.local = Y for existing mailboxes on active domains (fixes #537: '
+            . 'amavisd-new default SQL lookup misclassifies them as non-local, tripping the '
+            . 'open-relay heuristic and silently discarding inbound mail)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<SQL
+            UPDATE users
+            SET local = 'Y'
+            WHERE domain_id IN (SELECT id FROM domain WHERE active = 1)
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql(<<<SQL
+            UPDATE users
+            SET local = NULL
+            WHERE domain_id IN (SELECT id FROM domain WHERE active = 1)
+        SQL);
+    }
+}

--- a/app/src/Controller/UserController.php
+++ b/app/src/Controller/UserController.php
@@ -380,6 +380,10 @@ class UserController extends AbstractController
                 $user->setRoles('["ROLE_USER"]');
                 $user->setUsername($user->getEmail());
                 $user->setDomain($newDomain);
+                // Marks the account as local for amavisd-new's default SQL
+                // policy lookup, so mail to this address isn't misclassified
+                // as a suspected open relay (see issue #537).
+                $user->setLocal('Y');
 
                 $policy = $this->computeUserPolicy($user);
                 $user->setPolicy($policy);


### PR DESCRIPTION
## Related issue(s)
https://github.com/Probesys/agentj/issues/537

## How to test manually
1. Create a new mailbox on a protected domain (Admin > Users > new email user).
2. Check the `users` table: the new row should have `local = 'Y'`.
3. Send a legitimate test email to that address.
4. Check the amavis log: the message should be tagged `DiscardedInbound` / go through normal human-auth/quarantine policy — not `DiscardedOpenRelay`.
5. Run the migration on a database with pre-existing mailboxes (e.g. a copy of a domain with a few active users): confirm `local` is set to `Y` only for users whose `domain_id` belongs to an active domain.

## Reviewer checklist
- [ ] Code is manually tested
- [ ] Interface works on both mobiles and big screens
- [ ] Interface works on both Firefox and Chrome
- [ ] Tests are up to date
- [ ] Documentation is up to date
- [ ] Pull request has been reviewed and approved
