### PR TITLE
Fix: amavis release wrongly marked as delivered on MTA temp failure

### DIFF
--- a/app/src/MessageHandler/AmavisReleaseHandler.php
+++ b/app/src/MessageHandler/AmavisReleaseHandler.php
@@ -89,18 +89,29 @@ final class AmavisReleaseHandler
             $messageRecipient->getAddress()->getEmail(),
         ]);
 
+        $messageRecipient->setAmavisOutput('');
         $process->run(
             function ($type, $buffer) use ($messageRecipient) {
-                $messageRecipient->setAmavisOutput($buffer);
+                $messageRecipient->setAmavisOutput($messageRecipient->getAmavisOutput() . $buffer);
             }
         );
 
-        if (!$process->isSuccessful()) {
+        // amavisd-release only reports whether it could talk to amavisd over
+        // the AM.PDP socket: it exits successfully even when the downstream
+        // MTA rejects the actual re-injection (e.g. a temporary "452 4.3.1
+        // Insufficient system storage"). The real outcome is the SMTP-style
+        // reply amavisd forwards to us in its output, so it must be checked
+        // too, otherwise a failed release still gets marked as released and
+        // can never be retried.
+        $amavisOutput = $messageRecipient->getAmavisOutput() ?? '';
+        $mtaAccepted = (bool) preg_match('/^\s*2\d\d[\s.]/', $amavisOutput);
+
+        if (!$process->isSuccessful() || !$mtaAccepted) {
             $this->logger->error('Amavis release failed', [
                 'mailId' => $messageRecipient->getMailId(),
                 'partitionTag' => $messageRecipient->getPartitionTag(),
                 'rseqnum' => $messageRecipient->getRseqnum(),
-                'output' => $process->getErrorOutput(),
+                'output' => $amavisOutput !== '' ? $amavisOutput : $process->getErrorOutput(),
             ]);
             $messageRecipient->setStatus(MessageStatus::ERROR);
         } else {


### PR DESCRIPTION
## Related issue(s)

Closes #611

## How to test manually

1. Release a quarantined message for a recipient whose mail delivery you can make temporarily fail (e.g. point the domain's mailbox quota to 0, or otherwise make the downstream MTA answer with a 4xx/5xx on port 10025).
2. Trigger the release (portal "restore"/"authorize", or `agentj:auto-release-message`).
3. Before the fix: `msgrcpt.status_id` ends up `AUTHORIZED`/`RESTORED` even though the mail was rejected, and a further click on "restore" silently does nothing.
4. After the fix: `msgrcpt.status_id` is `ERROR` and `amavis_output` holds the MTA's actual reply; clicking "restore" again re-attempts the release (and succeeds once delivery is possible again).
5. Sanity check the happy path is unaffected: a normal release (MTA replies `2xx`) still ends up `AUTHORIZED`/`RESTORED` as before.

## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [ ] Code is manually tested
- [ ] Interface works on both mobiles and big screens
- [ ] Interface works on both Firefox and Chrome
- [ ] Tests are up to date
- [ ] Documentation is up to date
- [ ] Pull request has been reviewed and approved
