### PR TITLE
Fix: install the Mail::DMARC Perl module (DMARC check is a no-op without it)

### DIFF
--- a/amavis/Dockerfile
+++ b/amavis/Dockerfile
@@ -21,6 +21,7 @@ RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt,sharing=locked \
     spamassassin \
     gnupg \
     libmail-spf-perl \
+    libmail-dmarc-perl \
     libencode-detect-perl \
     libio-socket-ssl-perl \
     libnet-patricia-perl \


### PR DESCRIPTION
## Related issue(s)

N/A directly, but related to #613 (this fix alone doesn't close it — see that issue for the bigger incoming anti-spoofing proposal this doesn't cover).

## How to test manually

1. Rebuild the amavis image and start a container from it.
2. `docker exec <amavis container> spamassassin --lint -D 2>&1 | grep -i dmarc`
3. Before the fix: `optional module not installed: Mail::DMARC ('require' failed)`.
4. After the fix: `optional module installed: Mail::DMARC, version ...` and no more "require failed" warning.
5. Send/receive a test message from a domain publishing `p=reject`/`p=quarantine` with a failing DMARC alignment and check `DMARC_REJECT`/`DMARC_QUAR` now appears in the SpamAssassin report (`X-Spam-Status` / amavis headers), where it previously never fired.

## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [ ] Code is manually tested
- [ ] Interface works on both mobiles and big screens
- [ ] Interface works on both Firefox and Chrome
- [ ] Tests are up to date
- [ ] Documentation is up to date
- [ ] Pull request has been reviewed and approved
