### PR TITLE
Fix: dashboard status chart showing raw translation keys instead of text

### DIFF
--- a/app/templates/base.html.twig
+++ b/app/templates/base.html.twig
@@ -73,6 +73,12 @@
             'Generics.flash.editSuccess': 'Generics.flash.editSuccess' | trans,
             'Generics.labels.yes': 'Generics.labels.yes' | trans,
             'Generics.labels.cancel': 'Generics.labels.cancel' | trans,
+            'Navigation.untreated': 'Navigation.untreated' | trans,
+            'Navigation.authorized': 'Navigation.authorized' | trans,
+            'Navigation.banned': 'Navigation.banned' | trans,
+            'Navigation.Messagedelete': 'Navigation.Messagedelete' | trans,
+            'Navigation.MessageRestored': 'Navigation.MessageRestored' | trans,
+            'Navigation.mailBlocked': 'Navigation.mailBlocked' | trans,
         } | json_encode | raw }};
     </script>
   </body>


### PR DESCRIPTION
## Related issue(s)
https://github.com/Probesys/agentj/issues/616

## How to test manually
1. Go to the dashboard.
2. Look at the message-status doughnut chart labels.
3. Before: some labels showed the raw translation key (e.g. `Navigation.authorized`) instead of translated text.
4. After: all labels show the translated text (e.g. "Autorisés" in French).

## Reviewer checklist

- [ ] Code is manually tested
- [ ] Interface works on both mobiles and big screens
- [ ] Interface works on both Firefox and Chrome
- [ ] Tests are up to date
- [ ] Documentation is up to date
- [ ] Pull request has been reviewed and approved