### PR TITLE
fix: add missing quotes around body parameter

### DIFF
--- a/scripts/mail_to_agentj.sh
+++ b/scripts/mail_to_agentj.sh
@@ -88,7 +88,7 @@ if [ "$spam" = true ] ; then
 fi
 
 command="swaks --from '${from}' --to '${joined:-$to}' --server '$ip_smtptest':26 \
-	--h-Subject '$subject' --body $body"
+	--h-Subject '$subject' --body \"$body\""
 
 for h in "${headers[@]}"; do
     command="$command --add-header $h"

--- a/scripts/mail_via_agentj.sh
+++ b/scripts/mail_via_agentj.sh
@@ -88,7 +88,7 @@ if [ "$spam" = true ] ; then
 fi
 
 command="swaks --from '${from}' --to '${joined:-$to}' --server '$ip_smtptest':27 \
-	--h-Subject '$subject' --body $body"
+	--h-Subject '$subject' --body \"$body\""
 
 for h in "${headers[@]}"; do
     command="$command --add-header $h"


### PR DESCRIPTION
## Related issue(s)
<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

## How to test manually
<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->
On `main`, commands fail:
- ./scripts/mail_to_agentj.sh -c '<html><body><strong>test</strong></body></html>'
- ./scripts/mail_via_agentj.sh -c '<html><body><strong>test</strong></body></html>'

On `fix/send-mails-script-with-body`, commands succeed:
- ./scripts/mail_to_agentj.sh -c '<html><body><strong>test</strong></body></html>'
- ./scripts/mail_via_agentj.sh -c '<html><body><strong>test</strong></body></html>'

## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [ ] Code is manually tested
- [ ] Interface works on both mobiles and big screens
- [ ] Interface works on both Firefox and Chrome
- [ ] Tests are up to date
- [ ] Documentation is up to date
- [ ] Pull request has been reviewed and approved
