### PR TITLE
fix: list impersonated user's shared boxes when impersonating as admin

### DIFF
--- a/app/src/Security/SwitchToUserVoter.php
+++ b/app/src/Security/SwitchToUserVoter.php
@@ -3,7 +3,6 @@
 namespace App\Security;
 
 use App\Entity\User;
-use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\Vote;
 use Symfony\Component\Security\Core\Authorization\Voter\Voter;
@@ -11,7 +10,7 @@ use Symfony\Component\Security\Core\Authorization\Voter\Voter;
 class SwitchToUserVoter extends Voter
 {
     public function __construct(
-        private Security $security,
+        private SwitchUserAuthorization $switchUserAuthorization,
     ) {
     }
 
@@ -33,36 +32,6 @@ class SwitchToUserVoter extends Voter
             return false;
         }
 
-        $targetUser = $subject;
-        $targetUserDomain = $targetUser->getDomain();
-
-        // Super admins can switch to any user they want.
-        if ($this->security->isGrantedForUser($user, 'ROLE_SUPER_ADMIN')) {
-            return true;
-        }
-
-        // Make sure that only super admins can impersonate other super admins.
-        if ($this->security->isGrantedForUser($targetUser, 'ROLE_SUPER_ADMIN')) {
-            return false;
-        }
-
-        // Admins can only switch to users being part of the domains they manage.
-        if (
-            $this->security->isGrantedForUser($user, 'ROLE_ADMIN') &&
-            $user->hasDomain($targetUserDomain)
-        ) {
-            return true;
-        }
-
-        // If a user attempts to switch to another user, the target user must
-        // be shared with the user.
-        if (
-            $this->security->isGrantedForUser($user, 'ROLE_USER') &&
-            $targetUser->isSharedWith($user)
-        ) {
-            return true;
-        }
-
-        return false;
+        return $this->switchUserAuthorization->canSwitch($user, $subject);
     }
 }

--- a/app/src/Security/SwitchUserAuthorization.php
+++ b/app/src/Security/SwitchUserAuthorization.php
@@ -22,12 +22,7 @@ class SwitchUserAuthorization
             return false;
         }
 
-        $targetDomain = $targetUser->getDomain();
-        if (
-            $this->security->isGrantedForUser($user, 'ROLE_ADMIN')
-            && $targetDomain !== null
-            && $user->hasDomain($targetDomain)
-        ) {
+        if ($this->security->isGrantedForUser($user, 'DOMAIN_ACCESS', $targetUser)) {
             return true;
         }
 

--- a/app/src/Security/SwitchUserAuthorization.php
+++ b/app/src/Security/SwitchUserAuthorization.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Security;
+
+use App\Entity\User;
+use Symfony\Bundle\SecurityBundle\Security;
+
+class SwitchUserAuthorization
+{
+    public function __construct(
+        private Security $security,
+    ) {
+    }
+
+    public function canSwitch(User $user, User $targetUser): bool
+    {
+        if ($this->security->isGrantedForUser($user, 'ROLE_SUPER_ADMIN')) {
+            return true;
+        }
+
+        if ($this->security->isGrantedForUser($targetUser, 'ROLE_SUPER_ADMIN')) {
+            return false;
+        }
+
+        $targetDomain = $targetUser->getDomain();
+        if (
+            $this->security->isGrantedForUser($user, 'ROLE_ADMIN')
+            && $targetDomain !== null
+            && $user->hasDomain($targetDomain)
+        ) {
+            return true;
+        }
+
+        return $this->security->isGrantedForUser($user, 'ROLE_USER')
+            && $targetUser->isSharedWith($user);
+    }
+}

--- a/app/src/Twig/AppExtension.php
+++ b/app/src/Twig/AppExtension.php
@@ -7,6 +7,7 @@ use App\Entity\Group;
 use App\Entity\Message;
 use App\Entity\User;
 use App\Entity\SenderRule;
+use App\Security\SwitchUserAuthorization;
 use App\Service\LocaleService;
 use App\Service\MessageService;
 use Doctrine\ORM\EntityManagerInterface;
@@ -23,6 +24,7 @@ class AppExtension extends AbstractExtension
         private EntityManagerInterface $em,
         private MessageService $messageService,
         private Security $security,
+        private SwitchUserAuthorization $switchUserAuthorization,
         private Packages $packages,
         private string $uploadDirectory,
         private string $defaultLogoFilename,
@@ -46,6 +48,7 @@ class AppExtension extends AbstractExtension
         return [
             new TwigFunction('message_release_token', [$this, 'messageReleaseToken']),
             new TwigFunction('get_original_user', [$this, 'getOriginalUser']),
+            new TwigFunction('switchable_users', [$this, 'getSwitchableUsers']),
             new TwigFunction('domain_logo_asset', [$this, 'domainLogoAsset']),
             new TwigFunction('locales', [$this, 'locales']),
         ];
@@ -127,6 +130,34 @@ class AppExtension extends AbstractExtension
         }
 
         return null;
+    }
+
+    /**
+     * @return User[]
+     */
+    public function getSwitchableUsers(?User $originalUser): array
+    {
+        $currentUser = $this->security->getUser();
+
+        if (!$currentUser instanceof User) {
+            return [];
+        }
+
+        $switchingUser = $originalUser ?? $currentUser;
+        $isAdminSwitch = $originalUser !== null && $this->security->isGrantedForUser($originalUser, 'ROLE_ADMIN');
+
+        if ($isAdminSwitch) {
+            $users = $currentUser->getOwnedSharedBoxes()->toArray();
+        } else {
+            $users = $switchingUser->getOwnedSharedBoxes()->toArray();
+        }
+
+        return array_values(array_filter(
+            $users,
+            fn (User $user) => $user->getId() !== $currentUser->getId()
+                // For standard users, the source association already grants access.
+                && (!$isAdminSwitch || $this->switchUserAuthorization->canSwitch($switchingUser, $user)),
+        ));
     }
 
     /**

--- a/app/templates/header.html.twig
+++ b/app/templates/header.html.twig
@@ -61,19 +61,15 @@
                         <div class="dropdown-divider"></div>
                     {% endif %}
 
-                    {% if originalUser %}
-                        {% set sharedUsers = originalUser.ownedSharedBoxes | filter(sharedUser => sharedUser.id != app.user.id) %}
-                    {% else %}
-                        {% set sharedUsers = app.user.ownedSharedBoxes %}
-                    {% endif %}
+                    {% set switchableUsers = switchable_users(originalUser) %}
 
-                    {% if sharedUsers | length > 0 %}
+                    {% if switchableUsers | length > 0 %}
                         <div class="dropdown-header">{{ 'Navigation.mailboxes.other' | trans }}</div>
 
-                        {% for sharedUser in sharedUsers %}
-                            <a class="dropdown-item" href="{{ path('homepage', {'_switch_user': sharedUser.username}) }}" title="{{ 'Generics.actions.connectAs'|trans() ~ sharedUser.username}}">
+                        {% for switchableUser in switchableUsers %}
+                            <a class="dropdown-item" href="{{ path('homepage', {'_switch_user': switchableUser.username}) }}" title="{{ 'Generics.actions.connectAs'|trans() ~ switchableUser.username}}">
                                 <i class="fas fa-envelope"></i>
-                                {{ sharedUser.username }}
+                                {{ switchableUser.username }}
                             </a>
                         {% endfor %}
 

--- a/app/tests/Controller/MenuControllerTest.php
+++ b/app/tests/Controller/MenuControllerTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Tests\Controller;
+
+use App\Tests\Factory\DomainFactory;
+use App\Tests\Factory\UserFactory;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\DomCrawler\Crawler;
+use Symfony\Component\HttpFoundation\Request;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+class MenuControllerTest extends WebTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    public function testAdminSeesImpersonatedUsersSharedMailboxesFromManagedDomains(): void
+    {
+        $client = static::createClient();
+        $managedDomain = DomainFactory::createOne();
+        $admin = UserFactory::new()->admin([$managedDomain])->create();
+        $userB = UserFactory::new()->user($managedDomain)->create();
+        $userC = UserFactory::new()->user($managedDomain)->create(['sharedWith' => [$userB]]);
+        $otherDomainUser = UserFactory::new()->user(DomainFactory::createOne())->create(['sharedWith' => [$userB]]);
+        $client->loginUser($admin);
+
+        $client->request(Request::METHOD_GET, '/', ['_switch_user' => $userB->getUsername()]);
+        self::assertResponseRedirects('/', 302);
+
+        $crawler = $client->followRedirect();
+        self::assertResponseIsSuccessful();
+        $menuItems = $this->getUserMenuItems($crawler);
+
+        self::assertContains($userC->getUsername(), $menuItems);
+        self::assertNotContains($userB->getUsername(), $menuItems);
+        self::assertNotContains($otherDomainUser->getUsername(), $menuItems);
+    }
+
+    public function testUserSeesOtherSharedMailboxesWhenImpersonating(): void
+    {
+        $client = static::createClient();
+        $domain = DomainFactory::createOne();
+        $userA = UserFactory::new()->user($domain)->create();
+        $userB = UserFactory::new()->user($domain)->create(['sharedWith' => [$userA]]);
+        $userC = UserFactory::new()->user($domain)->create(['sharedWith' => [$userA]]);
+        $client->loginUser($userA);
+
+        $client->request(Request::METHOD_GET, '/', ['_switch_user' => $userB->getUsername()]);
+        self::assertResponseRedirects('/', 302);
+
+        $crawler = $client->followRedirect();
+        self::assertResponseIsSuccessful();
+        $menuItems = $this->getUserMenuItems($crawler);
+
+        self::assertContains($userC->getUsername(), $menuItems);
+        self::assertNotContains($userB->getUsername(), $menuItems);
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getUserMenuItems(Crawler $crawler): array
+    {
+        return $crawler
+            ->filter('#userDropdown + .dropdown-menu a.dropdown-item')
+            ->each(fn (Crawler $node) => trim($node->text()));
+    }
+}

--- a/app/tests/Security/SwitchToUserVoterTest.php
+++ b/app/tests/Security/SwitchToUserVoterTest.php
@@ -56,9 +56,10 @@ class SwitchToUserVoterTest extends WebTestCase
     {
         $client = static::createClient();
         // userA has access to both userB and userC's shared mailboxes.
-        $userA = UserFactory::new()->user()->create();
-        $userB = UserFactory::new()->user()->create(['sharedWith' => [$userA]]);
-        $userC = UserFactory::new()->user()->create(['sharedWith' => [$userA]]);
+        $domain = DomainFactory::createOne();
+        $userA = UserFactory::new()->user($domain)->create();
+        $userB = UserFactory::new()->user($domain)->create(['sharedWith' => [$userA]]);
+        $userC = UserFactory::new()->user($domain)->create(['sharedWith' => [$userA]]);
         $client->loginUser($userA);
 
         // userA switches to userB's mailbox.
@@ -76,14 +77,15 @@ class SwitchToUserVoterTest extends WebTestCase
     public function testUserCannotChainSwitchToAMailboxImpersonatedUserHasAccess(): void
     {
         $client = static::createClient();
-        $userA = UserFactory::new()->user()->create();
-        $userB = UserFactory::new()->user()->create(['sharedWith' => [$userA]]);
+        $domain = DomainFactory::createOne();
+        $userA = UserFactory::new()->user($domain)->create();
+        $userB = UserFactory::new()->user($domain)->create(['sharedWith' => [$userA]]);
         // userC is shared with userB but not userA. This case could be
         // legitimate (being careful with priviledge escalation), but
         // SwitchToUserVoter doesn't have access to the SwitchUserToken and so
         // we cannot support this case. It would probably require a different
         // system.
-        $userC = UserFactory::new()->user()->create(['sharedWith' => [$userB]]);
+        $userC = UserFactory::new()->user($domain)->create(['sharedWith' => [$userB]]);
         $client->loginUser($userA);
 
         $client->request(Request::METHOD_GET, '/', ['_switch_user' => $userB->getUsername()]);
@@ -96,8 +98,9 @@ class SwitchToUserVoterTest extends WebTestCase
     public function testUserCannotSwitchToAMailboxHeCannotAccess(): void
     {
         $client = static::createClient();
-        $userA = UserFactory::new()->user()->create();
-        $userB = UserFactory::new()->user()->create(['sharedWith' => []]);
+        $domain = DomainFactory::createOne();
+        $userA = UserFactory::new()->user($domain)->create();
+        $userB = UserFactory::new()->user($domain)->create(['sharedWith' => []]);
         $client->loginUser($userA);
 
         $client->request(Request::METHOD_GET, '/', ['_switch_user' => $userB->getUsername()]);


### PR DESCRIPTION
## Related issue(s)
#634 

## How to test manually

### Prerequisites

Create the following data:

1. A local admin `admin@example.test` assigned to the `example.test` domain.
2. A mailbox `user-b@example.test`.
3. A mailbox `user-c@example.test`, shared with `user-b@example.test`.
4. A mailbox `user-d@other.test`, shared with `user-b@example.test`.
5. Ensure that `admin@example.test` does not manage the `other.test` domain.

### Test steps

1. Log in directly as `admin@example.test`.
   Do not impersonate this admin from a super-admin account.
2. Go to the email users list and impersonate `user-b@example.test`.
3. Open the user menu.
4. Verify that `user-c@example.test` is listed as a shared mailbox.
5. Verify that `user-d@other.test` is not listed.
6. Click `user-c@example.test` and verify that impersonation succeeds.
7. Open `/?_switch_user=user-d@other.test` manually and verify that the application returns a `403` response.
8. Click "Exit impersonation" and verify that you are returned to `admin@example.test`.

## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [ ] Code is manually tested
- [ ] Interface works on both mobiles and big screens
- [ ] Interface works on both Firefox and Chrome
- [ ] Tests are up to date
- [ ] Documentation is up to date
- [ ] Pull request has been reviewed and approved
