### PR TITLE
fix: normalize sender rule addresses (#638)

### DIFF
--- a/app/migrations/Version20260910120000.php
+++ b/app/migrations/Version20260910120000.php
@@ -1,0 +1,377 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Exception\TableNotFoundException;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260910120000 extends AbstractMigration
+{
+    private const CONFLICT_LOG_ACTION = 'migration sender rule conflict resolved';
+    private const MAP_TABLE = 'tmp_rule_address_normalization_map';
+    private const GROUP_RULE_TABLE = 'tmp_normalized_group_rules';
+    private const SENDER_RULE_TABLE = 'tmp_normalized_sender_rules';
+    private const OUT_RULE_TABLE = 'tmp_normalized_out_rules';
+
+    private bool $hasOutRuleTable = false;
+
+    public function getDescription(): string
+    {
+        return 'Normalize and merge case-insensitive sender rule addresses, keeping the latest conflicting rule';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->abortIfInvalidAddresses();
+        $this->hasOutRuleTable = $this->hasOutRuleTable();
+        $this->dropTemporaryTables();
+        $this->addSql(<<<SQL
+            CREATE TEMPORARY TABLE {$this->table(self::MAP_TABLE)} (
+                old_sid INT UNSIGNED NOT NULL PRIMARY KEY,
+                keep_sid INT UNSIGNED NOT NULL,
+                normalized_email VARBINARY(255) NOT NULL,
+                KEY IDX_RULE_ADDRESS_KEEP_SID (keep_sid)
+            ) ENGINE=InnoDB
+        SQL);
+        $this->addSql(<<<SQL
+            INSERT INTO {$this->table(self::MAP_TABLE)} (old_sid, keep_sid, normalized_email)
+            SELECT old_sid, keep_sid, normalized_email
+            FROM (
+                SELECT
+                    id AS old_sid,
+                    normalized_email,
+                    COUNT(*) OVER (
+                        PARTITION BY normalized_email
+                    ) AS duplicate_count,
+                    COALESCE(
+                        MIN(CASE WHEN email = normalized_email THEN id END)
+                            OVER (PARTITION BY normalized_email),
+                        MIN(id) OVER (PARTITION BY normalized_email)
+                    ) AS keep_sid
+                FROM (
+                    SELECT
+                        id,
+                        email,
+                        CAST(LOWER(CONVERT(email USING utf8mb4)) AS BINARY) AS normalized_email
+                    FROM mailaddr
+                ) normalized_addresses
+            ) mapped_addresses
+            WHERE duplicate_count > 1
+        SQL);
+
+        $this->stageGroupRules();
+        $this->stageSenderRules('wblist', self::SENDER_RULE_TABLE);
+        if ($this->hasOutRuleTable) {
+            $this->stageSenderRules('out_wblist', self::OUT_RULE_TABLE);
+        }
+        $this->logGroupRuleConflicts();
+        $this->logSenderRuleConflicts('wblist');
+        if ($this->hasOutRuleTable) {
+            $this->logSenderRuleConflicts('out_wblist');
+        }
+
+        $this->replaceAffectedRules('groups_wblist', self::GROUP_RULE_TABLE, 'group_id, sid, wb');
+        $columns = 'rid, sid, group_id, wb, datemod, type, priority';
+        $this->replaceAffectedRules('wblist', self::SENDER_RULE_TABLE, $columns);
+        if ($this->hasOutRuleTable) {
+            $this->replaceAffectedRules('out_wblist', self::OUT_RULE_TABLE, $columns);
+        }
+
+        $this->addSql(<<<SQL
+            DELETE ma
+            FROM mailaddr ma
+            INNER JOIN {$this->table(self::MAP_TABLE)} map ON map.old_sid = ma.id
+            WHERE map.old_sid <> map.keep_sid
+        SQL);
+        $normalizedEmail = 'CAST(LOWER(CONVERT(ma.email USING utf8mb4)) AS BINARY)';
+        $computedPriority = $this->priorityExpression($normalizedEmail);
+        $this->addSql(<<<SQL
+            UPDATE mailaddr ma
+            SET ma.email = {$normalizedEmail}, ma.priority = {$computedPriority}
+            WHERE ma.email <> {$normalizedEmail} OR ma.priority <> {$computedPriority}
+        SQL);
+        $this->dropTemporaryTables();
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->throwIrreversibleMigrationException('The original RuleAddress casing cannot be restored.');
+    }
+
+    private function abortIfInvalidAddresses(): void
+    {
+        $invalidCount = (int) $this->connection->fetchOne(<<<'SQL'
+            SELECT COUNT(*)
+            FROM mailaddr
+            WHERE email <> CAST(CONVERT(email USING utf8mb4) AS BINARY)
+               OR OCTET_LENGTH(LOWER(CONVERT(email USING utf8mb4))) > 255
+        SQL);
+
+        $this->abortIf(
+            $invalidCount > 0,
+            "Cannot normalize RuleAddress: {$invalidCount} address(es) contain invalid UTF-8, "
+                . 'exceed 255 bytes, or require database-dependent Unicode case folding.',
+        );
+
+        $cursor = 0;
+        do {
+            $rows = $this->connection->fetchAllAssociative(<<<'SQL'
+                SELECT
+                    id,
+                    email,
+                    CAST(LOWER(CONVERT(email USING utf8mb4)) AS BINARY) AS normalized_email
+                FROM mailaddr
+                WHERE id > :cursor
+                  AND OCTET_LENGTH(email) <> CHAR_LENGTH(CONVERT(email USING utf8mb4))
+                ORDER BY id
+                LIMIT 1000
+            SQL, ['cursor' => $cursor]);
+
+            foreach ($rows as $row) {
+                $cursor = (int) $row['id'];
+                $normalizedEmail = mb_strtolower((string) $row['email'], 'UTF-8');
+                $this->abortIf(
+                    $normalizedEmail !== $row['normalized_email'] || strlen($normalizedEmail) > 255,
+                    'Cannot normalize RuleAddress: address ' . $row['id']
+                        . ' requires database-dependent Unicode case folding.',
+                );
+            }
+        } while (count($rows) === 1000);
+    }
+
+    private function hasOutRuleTable(): bool
+    {
+        try {
+            $this->connection->fetchOne('SELECT 1 FROM out_wblist LIMIT 1');
+            return true;
+        } catch (TableNotFoundException) {
+            return false;
+        }
+    }
+
+    private function stageGroupRules(): void
+    {
+        $this->addSql('CREATE TEMPORARY TABLE ' . self::GROUP_RULE_TABLE . ' LIKE groups_wblist');
+        $this->addSql(<<<SQL
+            INSERT INTO {$this->table(self::GROUP_RULE_TABLE)} (group_id, sid, wb)
+            SELECT group_id, keep_sid, wb
+            FROM (
+                SELECT
+                    gr.group_id,
+                    map.keep_sid,
+                    gr.wb,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY gr.group_id, map.keep_sid
+                        ORDER BY map.old_sid DESC
+                    ) AS rule_rank
+                FROM groups_wblist gr
+                INNER JOIN {$this->table(self::MAP_TABLE)} map ON map.old_sid = gr.sid
+            ) ranked_group_rules
+            WHERE rule_rank = 1
+        SQL);
+    }
+
+    private function stageSenderRules(string $sourceTable, string $temporaryTable): void
+    {
+        $this->addSql("CREATE TEMPORARY TABLE {$temporaryTable} LIKE {$sourceTable}");
+        $this->addSql(<<<SQL
+            INSERT INTO {$this->table($temporaryTable)} (rid, sid, group_id, wb, datemod, type, priority)
+            SELECT rid, keep_sid, group_id, wb, datemod, type, priority
+            FROM (
+                SELECT
+                    sr.rid,
+                    map.keep_sid,
+                    sr.group_id,
+                    sr.wb,
+                    sr.datemod,
+                    sr.type,
+                    sr.priority,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY sr.rid, map.keep_sid, sr.priority
+                        ORDER BY sr.datemod DESC, map.old_sid DESC
+                    ) AS rule_rank
+                FROM {$this->table($sourceTable)} sr
+                INNER JOIN {$this->table(self::MAP_TABLE)} map ON map.old_sid = sr.sid
+            ) ranked_sender_rules
+            WHERE rule_rank = 1
+        SQL);
+    }
+
+    private function replaceAffectedRules(string $targetTable, string $temporaryTable, string $columns): void
+    {
+        $this->addSql(<<<SQL
+            DELETE target
+            FROM {$this->table($targetTable)} target
+            INNER JOIN {$this->table(self::MAP_TABLE)} map ON map.old_sid = target.sid
+        SQL);
+        $this->addSql(<<<SQL
+            INSERT INTO {$this->table($targetTable)} ({$columns})
+            SELECT {$columns} FROM {$this->table($temporaryTable)}
+        SQL);
+    }
+
+    private function logGroupRuleConflicts(): void
+    {
+        $action = $this->actionExpression('gr.wb');
+        $logAction = self::CONFLICT_LOG_ACTION;
+        $this->addSql(<<<SQL
+            INSERT INTO log (action, mailId, details, created, updated)
+            SELECT
+                '{$logAction}',
+                NULL,
+                JSON_OBJECT(
+                    'table', 'groups_wblist',
+                    'address', CONVERT(normalized_email USING utf8mb4),
+                    'group_id', group_id,
+                    'kept_sid', winner_sid,
+                    'kept_action', winner_action,
+                    'kept_wb_hex', HEX(winner_wb),
+                    'discarded_sid', old_sid,
+                    'discarded_action', rule_action,
+                    'discarded_wb_hex', HEX(wb)
+                ),
+                NOW(),
+                NOW()
+            FROM (
+                SELECT
+                    gr.group_id,
+                    map.old_sid,
+                    map.normalized_email,
+                    gr.wb,
+                    {$action} AS rule_action,
+                    FIRST_VALUE(map.old_sid) OVER (
+                        PARTITION BY gr.group_id, map.keep_sid
+                        ORDER BY map.old_sid DESC
+                    ) AS winner_sid,
+                    FIRST_VALUE(gr.wb) OVER (
+                        PARTITION BY gr.group_id, map.keep_sid
+                        ORDER BY map.old_sid DESC
+                    ) AS winner_wb,
+                    FIRST_VALUE({$action}) OVER (
+                        PARTITION BY gr.group_id, map.keep_sid
+                        ORDER BY map.old_sid DESC
+                    ) AS winner_action,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY gr.group_id, map.keep_sid
+                        ORDER BY map.old_sid DESC
+                    ) AS rule_rank
+                FROM groups_wblist gr
+                INNER JOIN {$this->table(self::MAP_TABLE)} map ON map.old_sid = gr.sid
+            ) ranked_rules
+            WHERE rule_rank > 1 AND rule_action <> winner_action
+        SQL);
+    }
+
+    private function logSenderRuleConflicts(string $table): void
+    {
+        $action = $this->actionExpression('sr.wb');
+        $logAction = self::CONFLICT_LOG_ACTION;
+        $this->addSql(<<<SQL
+            INSERT INTO log (action, mailId, details, created, updated)
+            SELECT
+                '{$logAction}',
+                NULL,
+                JSON_OBJECT(
+                    'table', '{$this->table($table)}',
+                    'address', CONVERT(normalized_email USING utf8mb4),
+                    'recipient_id', rid,
+                    'priority', priority,
+                    'kept_sid', winner_sid,
+                    'kept_action', winner_action,
+                    'kept_wb_hex', HEX(winner_wb),
+                    'kept_datemod', winner_datemod,
+                    'discarded_sid', old_sid,
+                    'discarded_action', rule_action,
+                    'discarded_wb_hex', HEX(wb),
+                    'discarded_datemod', datemod
+                ),
+                NOW(),
+                NOW()
+            FROM (
+                SELECT
+                    sr.rid,
+                    sr.priority,
+                    map.old_sid,
+                    map.normalized_email,
+                    sr.wb,
+                    sr.datemod,
+                    {$action} AS rule_action,
+                    FIRST_VALUE(map.old_sid) OVER (
+                        PARTITION BY sr.rid, map.keep_sid, sr.priority
+                        ORDER BY sr.datemod DESC, map.old_sid DESC
+                    ) AS winner_sid,
+                    FIRST_VALUE(sr.wb) OVER (
+                        PARTITION BY sr.rid, map.keep_sid, sr.priority
+                        ORDER BY sr.datemod DESC, map.old_sid DESC
+                    ) AS winner_wb,
+                    FIRST_VALUE(sr.datemod) OVER (
+                        PARTITION BY sr.rid, map.keep_sid, sr.priority
+                        ORDER BY sr.datemod DESC, map.old_sid DESC
+                    ) AS winner_datemod,
+                    FIRST_VALUE({$action}) OVER (
+                        PARTITION BY sr.rid, map.keep_sid, sr.priority
+                        ORDER BY sr.datemod DESC, map.old_sid DESC
+                    ) AS winner_action,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY sr.rid, map.keep_sid, sr.priority
+                        ORDER BY sr.datemod DESC, map.old_sid DESC
+                    ) AS rule_rank
+                FROM {$this->table($table)} sr
+                INNER JOIN {$this->table(self::MAP_TABLE)} map ON map.old_sid = sr.sid
+            ) ranked_rules
+            WHERE rule_rank > 1 AND rule_action <> winner_action
+        SQL);
+    }
+
+    private function dropTemporaryTables(): void
+    {
+        foreach (
+            [self::GROUP_RULE_TABLE, self::SENDER_RULE_TABLE, self::OUT_RULE_TABLE, self::MAP_TABLE] as $table
+        ) {
+            $this->addSql("DROP TEMPORARY TABLE IF EXISTS {$table}");
+        }
+    }
+
+    private function priorityExpression(string $normalizedEmail): string
+    {
+        $email = "CONVERT({$normalizedEmail} USING utf8mb4)";
+        $domain = "SUBSTRING({$email}, 2)";
+        $domainPartCount = "LENGTH({$domain}) - LENGTH(REPLACE({$domain}, '.', '')) + 1";
+
+        return <<<SQL
+            CASE
+                WHEN {$email} = '@.' THEN 0
+                WHEN LEFT({$email}, 1) <> '@' THEN 6
+                WHEN LEFT({$domain}, 1) <> '.' THEN 5
+                WHEN ({$domainPartCount}) = 2 THEN 1
+                WHEN ({$domainPartCount}) = 3 THEN 2
+                WHEN ({$domainPartCount}) = 4 THEN 3
+                ELSE 5
+            END
+        SQL;
+    }
+
+    private function actionExpression(string $column): string
+    {
+        return <<<SQL
+            CASE HEX({$column})
+                WHEN '57' THEN 'allow'
+                WHEN '59' THEN 'allow'
+                WHEN '42' THEN 'block'
+                WHEN '4E' THEN 'block'
+                WHEN '20' THEN 'accept'
+                WHEN '30' THEN 'enabled'
+                WHEN '' THEN 'none'
+                ELSE CONCAT('raw:', HEX({$column}))
+            END
+        SQL;
+    }
+
+    private function table(string $table): string
+    {
+        return $table;
+    }
+}

--- a/app/migrations/Version20260910120000.php
+++ b/app/migrations/Version20260910120000.php
@@ -154,6 +154,7 @@ final class Version20260910120000 extends AbstractMigration
 
     private function stageGroupRules(): void
     {
+        $winnerOrder = $this->groupRuleWinnerOrder('gr.wb', 'map.old_sid');
         $this->addSql('CREATE TEMPORARY TABLE ' . self::GROUP_RULE_TABLE . ' LIKE groups_wblist');
         $this->addSql(<<<SQL
             INSERT INTO {$this->table(self::GROUP_RULE_TABLE)} (group_id, sid, wb)
@@ -165,7 +166,7 @@ final class Version20260910120000 extends AbstractMigration
                     gr.wb,
                     ROW_NUMBER() OVER (
                         PARTITION BY gr.group_id, map.keep_sid
-                        ORDER BY map.old_sid DESC
+                        ORDER BY {$winnerOrder}
                     ) AS rule_rank
                 FROM groups_wblist gr
                 INNER JOIN {$this->table(self::MAP_TABLE)} map ON map.old_sid = gr.sid
@@ -217,6 +218,7 @@ final class Version20260910120000 extends AbstractMigration
     {
         $action = $this->actionExpression('gr.wb');
         $logAction = self::CONFLICT_LOG_ACTION;
+        $winnerOrder = $this->groupRuleWinnerOrder('gr.wb', 'map.old_sid');
         $this->addSql(<<<SQL
             INSERT INTO log (action, mailId, details, created, updated)
             SELECT
@@ -226,7 +228,8 @@ final class Version20260910120000 extends AbstractMigration
                     'table', 'groups_wblist',
                     'address', CONVERT(normalized_email USING utf8mb4),
                     'group_id', group_id,
-                    'kept_sid', winner_sid,
+                    'kept_sid', keep_sid,
+                    'kept_source_sid', winner_source_sid,
                     'kept_action', winner_action,
                     'kept_wb_hex', HEX(winner_wb),
                     'discarded_sid', old_sid,
@@ -239,24 +242,25 @@ final class Version20260910120000 extends AbstractMigration
                 SELECT
                     gr.group_id,
                     map.old_sid,
+                    map.keep_sid,
                     map.normalized_email,
                     gr.wb,
                     {$action} AS rule_action,
                     FIRST_VALUE(map.old_sid) OVER (
                         PARTITION BY gr.group_id, map.keep_sid
-                        ORDER BY map.old_sid DESC
-                    ) AS winner_sid,
+                        ORDER BY {$winnerOrder}
+                    ) AS winner_source_sid,
                     FIRST_VALUE(gr.wb) OVER (
                         PARTITION BY gr.group_id, map.keep_sid
-                        ORDER BY map.old_sid DESC
+                        ORDER BY {$winnerOrder}
                     ) AS winner_wb,
                     FIRST_VALUE({$action}) OVER (
                         PARTITION BY gr.group_id, map.keep_sid
-                        ORDER BY map.old_sid DESC
+                        ORDER BY {$winnerOrder}
                     ) AS winner_action,
                     ROW_NUMBER() OVER (
                         PARTITION BY gr.group_id, map.keep_sid
-                        ORDER BY map.old_sid DESC
+                        ORDER BY {$winnerOrder}
                     ) AS rule_rank
                 FROM groups_wblist gr
                 INNER JOIN {$this->table(self::MAP_TABLE)} map ON map.old_sid = gr.sid
@@ -279,7 +283,8 @@ final class Version20260910120000 extends AbstractMigration
                     'address', CONVERT(normalized_email USING utf8mb4),
                     'recipient_id', rid,
                     'priority', priority,
-                    'kept_sid', winner_sid,
+                    'kept_sid', keep_sid,
+                    'kept_source_sid', winner_source_sid,
                     'kept_action', winner_action,
                     'kept_wb_hex', HEX(winner_wb),
                     'kept_datemod', winner_datemod,
@@ -295,6 +300,7 @@ final class Version20260910120000 extends AbstractMigration
                     sr.rid,
                     sr.priority,
                     map.old_sid,
+                    map.keep_sid,
                     map.normalized_email,
                     sr.wb,
                     sr.datemod,
@@ -302,7 +308,7 @@ final class Version20260910120000 extends AbstractMigration
                     FIRST_VALUE(map.old_sid) OVER (
                         PARTITION BY sr.rid, map.keep_sid, sr.priority
                         ORDER BY sr.datemod DESC, map.old_sid DESC
-                    ) AS winner_sid,
+                    ) AS winner_source_sid,
                     FIRST_VALUE(sr.wb) OVER (
                         PARTITION BY sr.rid, map.keep_sid, sr.priority
                         ORDER BY sr.datemod DESC, map.old_sid DESC
@@ -367,6 +373,22 @@ final class Version20260910120000 extends AbstractMigration
                 WHEN '' THEN 'none'
                 ELSE CONCAT('raw:', HEX({$column}))
             END
+        SQL;
+    }
+
+    private function groupRuleWinnerOrder(string $wbColumn, string $sidColumn): string
+    {
+        // Group rules have no modification date, so resolve unknown chronology conservatively.
+        return <<<SQL
+            CASE HEX({$wbColumn})
+                WHEN '42' THEN 3
+                WHEN '4E' THEN 3
+                WHEN '20' THEN 2
+                WHEN '57' THEN 1
+                WHEN '59' THEN 1
+                ELSE 0
+            END DESC,
+            {$sidColumn} DESC
         SQL;
     }
 

--- a/app/src/Command/RecoverAuthorizedSpamCommand.php
+++ b/app/src/Command/RecoverAuthorizedSpamCommand.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace App\Command;
+
+use App\Amavis\MessageStatus;
+use App\Repository\MessageRecipientRepository;
+use App\Repository\SenderRuleRepository;
+use App\Repository\UserRepository;
+use App\Service\MessageService;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Lock\LockFactory;
+
+#[AsCommand(
+    name: 'agentj:recover-authorized-spam',
+    description: 'Release messages incorrectly classified as spam for an authorized sender',
+)]
+class RecoverAuthorizedSpamCommand extends Command
+{
+    public function __construct(
+        private MessageRecipientRepository $messageRecipientRepository,
+        private UserRepository $userRepository,
+        private SenderRuleRepository $senderRuleRepository,
+        private MessageService $messageService,
+        private LockFactory $lockFactory,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption(
+                'since',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Only inspect messages received on or after this ISO-8601 date',
+            )
+            ->addOption('release', null, InputOption::VALUE_NONE, 'Release the reported messages')
+            ->addOption('batch-size', null, InputOption::VALUE_REQUIRED, 'Number of messages read per batch', '500');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $sinceValue = $input->getOption('since');
+        if (!is_string($sinceValue) || $sinceValue === '') {
+            $output->writeln('<error>The --since option is required.</error>');
+            return Command::INVALID;
+        }
+
+        try {
+            $since = new \DateTimeImmutable($sinceValue);
+        } catch (\Exception) {
+            $output->writeln('<error>The --since option must contain a valid ISO-8601 date.</error>');
+            return Command::INVALID;
+        }
+
+        $batchSize = filter_var($input->getOption('batch-size'), FILTER_VALIDATE_INT, [
+            'options' => ['min_range' => 1, 'max_range' => 5000],
+        ]);
+        if ($batchSize === false) {
+            $output->writeln('<error>The --batch-size option must be between 1 and 5000.</error>');
+            return Command::INVALID;
+        }
+
+        $lock = $this->lockFactory->createLock('recover-authorized-spam', ttl: 3600);
+        if (!$lock->acquire()) {
+            $output->writeln('<error>The recovery command is already running.</error>');
+            return Command::FAILURE;
+        }
+
+        $release = (bool) $input->getOption('release');
+        $until = time();
+        $cursor = null;
+        $inspectedCount = 0;
+        $recoverableCount = 0;
+
+        $output->writeln(
+            '<comment>Messages with a retained "marked as spam" audit log are excluded.</comment>',
+        );
+
+        try {
+            do {
+                $messageRecipients = $this->messageRecipientRepository->findSpammedSinceAfter(
+                    $since->getTimestamp(),
+                    $until,
+                    $cursor,
+                    $batchSize,
+                );
+
+                foreach ($messageRecipients as $messageRecipient) {
+                    $message = $messageRecipient->getMessage();
+                    $cursor = [
+                        'timeNum' => (int) $message->getTimeNum(),
+                        'partitionTag' => $messageRecipient->getPartitionTag(),
+                        'mailId' => $messageRecipient->getMailId(),
+                        'rseqnum' => (int) $messageRecipient->getRseqnum(),
+                    ];
+                    ++$inspectedCount;
+
+                    $recipientUser = $this->userRepository->findOneByAddress($messageRecipient->getAddress());
+                    $senderEmail = $message->getSenderEmail();
+                    if ($recipientUser === null || $senderEmail === null) {
+                        continue;
+                    }
+
+                    $recipientUser = $recipientUser->getOriginalUser() ?? $recipientUser;
+                    $senderIsAuthorized = $this->senderRuleRepository->isSenderAuthorizedByRecipient(
+                        $senderEmail,
+                        $messageRecipient->getAddress(),
+                    );
+                    $isSpamForAuthorizedSender = $messageRecipient->isSpamAtLevel(
+                        $recipientUser->getDomain()->getAuthorizedSendersSpamLevel(),
+                    );
+                    if (!$senderIsAuthorized || $isSpamForAuthorizedSender) {
+                        continue;
+                    }
+
+                    ++$recoverableCount;
+                    if ($output->isVerbose()) {
+                        $output->writeln(sprintf(
+                            '%s -> %s; score %.2f; authorized threshold %.2f; mail %s/%s/%s',
+                            $senderEmail,
+                            $messageRecipient->getAddress()->getEmail(),
+                            $messageRecipient->getBspamLevel(),
+                            $recipientUser->getDomain()->getAuthorizedSendersSpamLevel(),
+                            $messageRecipient->getPartitionTag(),
+                            $messageRecipient->getMailId(),
+                            $messageRecipient->getRseqnum(),
+                        ));
+                    }
+                    if ($release) {
+                        $this->messageService->dispatchRelease($messageRecipient, MessageStatus::AUTHORIZED);
+                    }
+                }
+
+                $lock->refresh();
+            } while (count($messageRecipients) === $batchSize);
+        } finally {
+            $lock->release();
+        }
+
+        $action = $release ? 'were queued for release' : 'would be released';
+        $output->writeln(
+            "Inspected {$inspectedCount} spammed message(s); {$recoverableCount} {$action}.",
+        );
+
+        return Command::SUCCESS;
+    }
+}

--- a/app/src/Controller/DomainController.php
+++ b/app/src/Controller/DomainController.php
@@ -5,15 +5,14 @@ namespace App\Controller;
 use App\Entity\Domain;
 use App\Entity\DomainKey;
 use App\Entity\Policy;
-use App\Entity\RuleAddress;
 use App\Entity\SenderRule;
 use App\Entity\User;
 use App\Form\DomainType;
 use App\Model\ConnectorTypes;
 use App\Repository\DomainRepository;
+use App\Repository\RuleAddressRepository;
 use App\Repository\SenderRuleRepository;
 use App\Repository\SettingRepository;
-use App\Service\RuleAddressService;
 use App\Service\UserService;
 use Doctrine\ORM\EntityManagerInterface;
 use Knp\Component\Pager\PaginatorInterface;
@@ -81,6 +80,7 @@ class DomainController extends AbstractController
     public function new(
         Request $request,
         ParameterBagInterface $params,
+        RuleAddressRepository $ruleAddressRepository,
         SettingRepository $settingRepository,
     ): Response {
         $domain = new Domain();
@@ -139,13 +139,7 @@ class DomainController extends AbstractController
             $wbRule = $form->get("wbRule")->getData();
 
             //for all domain @.
-            $ruleAddress = $this->em->getRepository(RuleAddress::class)->findOneBy((['email' => '@.']));
-            if (!$ruleAddress) {
-                $ruleAddress = new RuleAddress();
-                $ruleAddress->setPriority(0); // priority for domain is 0
-                $ruleAddress->setEmail('@.');
-                $this->em->persist($ruleAddress);
-            }
+            $ruleAddress = $ruleAddressRepository->findOneOrCreateByEmail('@.', flush: false);
             $senderRule = new SenderRule($user, $ruleAddress);
             $senderRule->setWbRule($wbRule);
             $senderRule->setPriority(SenderRule::PRIORITY_DOMAIN);
@@ -309,8 +303,11 @@ class DomainController extends AbstractController
 
     #[Route(path: '/{id}/rules/new', name: 'domain_sender_rules_new', methods: 'GET|POST')]
     #[IsGranted('DOMAIN_ACCESS', subject: 'domain')]
-    public function newSenderRule(Domain $domain, Request $request, RuleAddressService $ruleAddressService): Response
-    {
+    public function newSenderRule(
+        Domain $domain,
+        Request $request,
+        RuleAddressRepository $ruleAddressRepository,
+    ): Response {
         $user = $this->em->getRepository(User::class)->findOneBy(['email' => '@' . $domain->getDomain()]);
         $formBuilder = $this->createFormBuilder(null, [
             'action' => $this->generateUrl('domain_sender_rules_new', ['id' => $domain->getId()]),
@@ -330,25 +327,14 @@ class DomainController extends AbstractController
         if ($form->isSubmitted() && $form->isValid()) {
             $data = $form->getData();
 
-            $ruleAddress = $this->em->getRepository(RuleAddress::class)->findOneBy((['email' => $data['email']]));
-
-            if (!$ruleAddress) {
-                $ruleAddress = new RuleAddress();
-                $ruleAddress->setEmail($data['email']);
-
-                $priority = $ruleAddressService->computePriority($data['email']);
-                $ruleAddress->setPriority($priority);
-
-                $this->em->persist($ruleAddress);
-            } else {
-                $domainSenderRuleExists = $this->em->getRepository(SenderRule::class)->findOneBy(([
-                    'user' => $user,
-                    'senderRuleAddress' => $ruleAddress,
-                ]));
-                if ($domainSenderRuleExists) {
-                    $this->addFlash('danger', $this->translator->trans('Message.Flash.ruleExistForDomain'));
-                    return $this->redirectToRoute('domain_sender_rules_index', ['id' => $domain->getId()]);
-                }
+            $ruleAddress = $ruleAddressRepository->findOneOrCreateByEmail($data['email'], flush: false);
+            $domainSenderRuleExists = $this->em->getRepository(SenderRule::class)->findOneBy(([
+                'user' => $user,
+                'senderRuleAddress' => $ruleAddress,
+            ]));
+            if ($domainSenderRuleExists) {
+                $this->addFlash('danger', $this->translator->trans('Message.Flash.ruleExistForDomain'));
+                return $this->redirectToRoute('domain_sender_rules_index', ['id' => $domain->getId()]);
             }
             $senderRule = new SenderRule($user, $ruleAddress);
             $senderRule->setWbRule($data['wbRule']);

--- a/app/src/Controller/GroupController.php
+++ b/app/src/Controller/GroupController.php
@@ -5,7 +5,6 @@ namespace App\Controller;
 use App\Entity\Domain;
 use App\Entity\Group;
 use App\Entity\GroupRule;
-use App\Entity\RuleAddress;
 use App\Entity\User;
 use App\Form\GroupType;
 use App\Repository\DomainRepository;
@@ -73,7 +72,7 @@ class GroupController extends AbstractController
     }
 
     #[Route(path: '/new', name: 'group_new', methods: 'GET|POST')]
-    public function new(Request $request): Response
+    public function new(Request $request, RuleAddressRepository $ruleAddressRepository): Response
     {
         $group = new Group();
         if ($this->isGranted('ROLE_SUPER_ADMIN')) {
@@ -100,12 +99,7 @@ class GroupController extends AbstractController
 
             $this->em->persist($group);
 
-            $ruleAddress = $this->em->getRepository(RuleAddress::class)->findOneBy((['email' => '@.']));
-            if (!$ruleAddress) {
-                $ruleAddress = new RuleAddress();
-                $ruleAddress->setEmail('@.');
-                $this->em->persist($ruleAddress);
-            }
+            $ruleAddress = $ruleAddressRepository->findOneOrCreateByEmail('@.', flush: false);
             $groupRule = new GroupRule();
             $groupRule->setRuleAddress($ruleAddress);
             $groupRule->setGroup($group);

--- a/app/src/Controller/GroupRuleController.php
+++ b/app/src/Controller/GroupRuleController.php
@@ -4,11 +4,10 @@ namespace App\Controller;
 
 use App\Entity\Group;
 use App\Entity\GroupRule;
-use App\Entity\RuleAddress;
 use App\Form\GroupRuleType;
 use App\Repository\GroupRuleRepository;
+use App\Repository\RuleAddressRepository;
 use App\Service\GroupService;
-use App\Service\RuleAddressService;
 use Doctrine\ORM\EntityManagerInterface;
 use Knp\Component\Pager\PaginatorInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -75,7 +74,7 @@ class GroupRuleController extends AbstractController
     public function new(
         int $groupId,
         Request $request,
-        RuleAddressService $ruleAddressService,
+        RuleAddressRepository $ruleAddressRepository,
         GroupService $groupService,
     ): Response {
         $group = $this->em->getRepository(Group::class)->findOneBy((['id' => $groupId]));
@@ -96,21 +95,14 @@ class GroupRuleController extends AbstractController
 
             $data = $form->getData();
 
-            $ruleAddress = $this->em->getRepository(RuleAddress::class)->findOneBy((['email' => $data['email']]));
-            if (!$ruleAddress) {
-                $ruleAddress = new RuleAddress();
-                $ruleAddress->setEmail($data['email']);
-                $ruleAddress->setPriority($ruleAddressService->computePriority($data['email']));
-                $em->persist($ruleAddress);
-            } else {
-                $groupRuleExists = $this->em->getRepository(GroupRule::class)->findOneBy(([
-                    'ruleAddress' => $ruleAddress,
-                    'group' => $group,
-                ]));
-                if ($groupRuleExists) {
-                    $this->addFlash('warning', $this->translator->trans('Message.Flash.ruleExists'));
-                    return $this->redirectToRoute('groups_rules_index', ['groupId' => $groupId]);
-                }
+            $ruleAddress = $ruleAddressRepository->findOneOrCreateByEmail($data['email'], flush: false);
+            $groupRuleExists = $this->em->getRepository(GroupRule::class)->findOneBy(([
+                'ruleAddress' => $ruleAddress,
+                'group' => $group,
+            ]));
+            if ($groupRuleExists) {
+                $this->addFlash('warning', $this->translator->trans('Message.Flash.ruleExists'));
+                return $this->redirectToRoute('groups_rules_index', ['groupId' => $groupId]);
             }
 
             $groupRule->setRuleAddress($ruleAddress);
@@ -139,7 +131,7 @@ class GroupRuleController extends AbstractController
         int $groupId,
         int $sid,
         Request $request,
-        RuleAddressService $ruleAddressService,
+        RuleAddressRepository $ruleAddressRepository,
         GroupService $groupService,
     ): Response {
         $groupRule = $this->em->getRepository(GroupRule::class)->findOneBy([
@@ -157,21 +149,14 @@ class GroupRuleController extends AbstractController
 
             $data = $form->getData();
 
-            $ruleAddress = $this->em->getRepository(RuleAddress::class)->findOneBy((['email' => $data['email']]));
-            if (!$ruleAddress) {
-                $ruleAddress = new RuleAddress();
-                $ruleAddress->setEmail($data['email']);
-                $ruleAddress->setPriority($ruleAddressService->computePriority($data['email']));
-                $em->persist($ruleAddress);
-            } else {
-                $groupRuleExists = $this->em->getRepository(GroupRule::class)->findOneBy(([
-                    'ruleAddress' => $ruleAddress,
-                    'group' => $group,
-                ]));
-                if ($groupRuleExists && $ruleAddress != $groupRule->getRuleAddress()) {
-                    $this->addFlash('warning', $this->translator->trans('Message.Flash.ruleExists'));
-                    return $this->redirectToRoute('groups_rules_new', ['groupId' => $groupId]);
-                }
+            $ruleAddress = $ruleAddressRepository->findOneOrCreateByEmail($data['email'], flush: false);
+            $groupRuleExists = $this->em->getRepository(GroupRule::class)->findOneBy(([
+                'ruleAddress' => $ruleAddress,
+                'group' => $group,
+            ]));
+            if ($groupRuleExists && $ruleAddress != $groupRule->getRuleAddress()) {
+                $this->addFlash('warning', $this->translator->trans('Message.Flash.ruleExists'));
+                return $this->redirectToRoute('groups_rules_new', ['groupId' => $groupId]);
             }
 
             $groupRule->setRuleAddress($ruleAddress);

--- a/app/src/Controller/SenderRuleController.php
+++ b/app/src/Controller/SenderRuleController.php
@@ -3,11 +3,11 @@
 namespace App\Controller;
 
 use App\Entity\Domain;
-use App\Entity\RuleAddress;
 use App\Entity\SenderRule;
 use App\Entity\User;
 use App\Form\ActionsFilterType;
 use App\Form\ImportType;
+use App\Repository\RuleAddressRepository;
 use App\Repository\SenderRuleRepository;
 use App\Service\LogService;
 use App\Service\Referrer;
@@ -28,6 +28,8 @@ class SenderRuleController extends AbstractController
         private TranslatorInterface $translator,
         private EntityManagerInterface $em,
         private Referrer $referrer,
+        private RuleAddressRepository $ruleAddressRepository,
+        private SenderRuleRepository $senderRuleRepository,
     ) {
     }
 
@@ -238,15 +240,7 @@ class SenderRuleController extends AbstractController
                     continue;
                 }
 
-                $senderRuleAddress = $this->em->getRepository(RuleAddress::class)->findOneBy(['email' => $data]);
-                // if email doesn't exist then we create email in RuleAddress
-                if (!$senderRuleAddress) {
-                    $senderRuleAddress = new RuleAddress();
-                    $senderRuleAddress->setEmail($data);
-                    $senderRuleAddress->setPriority(6);
-                    $this->em->persist($senderRuleAddress);
-                    $this->em->flush();
-                }
+                $senderRuleAddress = $this->ruleAddressRepository->findOneOrCreateByEmail($data);
 
                 if (
                     isset($senderRules[$domain->getId()]) &&
@@ -256,18 +250,14 @@ class SenderRuleController extends AbstractController
                 }
 
                 $user = $this->em->getRepository(User::class)->findOneBy(['email' =>  '@' . $domain->getDomain()]);
-                $senderRule = $this->em->getRepository(SenderRule::class)->findOneBy([
-                    'senderRuleAddress' => $senderRuleAddress,
-                    'user' => $user,
-                ]);
-                if (!$senderRule) {
-                    $senderRule = new SenderRule($user, $senderRuleAddress);
-                }
-
-                $senderRule->setWbRule($rule);
-                $senderRule->setPriority(SenderRule::PRIORITY_USER);
-                $senderRule->setType(SenderRule::TYPE_IMPORT);
-                $this->em->persist($senderRule);
+                $this->senderRuleRepository->updateOrCreateRule(
+                    $user,
+                    $senderRuleAddress,
+                    wbRule: $rule,
+                    type: SenderRule::TYPE_IMPORT,
+                    priority: SenderRule::PRIORITY_USER,
+                    flush: false,
+                );
                 $senderRules[$domain->getId()][] = $senderRuleAddress->getId();
             }
 

--- a/app/src/Entity/RuleAddress.php
+++ b/app/src/Entity/RuleAddress.php
@@ -3,6 +3,7 @@
 namespace App\Entity;
 
 use App\Repository\RuleAddressRepository;
+use App\Util\Email;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
@@ -47,7 +48,7 @@ class RuleAddress
 
     public function setEmail(string $email): self
     {
-        $this->email = $email;
+        $this->email = Email::normalize($email);
 
         return $this;
     }

--- a/app/src/Repository/MessageRecipientRepository.php
+++ b/app/src/Repository/MessageRecipientRepository.php
@@ -44,6 +44,63 @@ class MessageRecipientRepository extends BaseRepository
     }
 
     /**
+     * @param null|array{timeNum: int, partitionTag: int, mailId: string, rseqnum: int} $cursor
+     * @return MessageRecipient[]
+     */
+    public function findSpammedSinceAfter(int $since, int $until, ?array $cursor, int $limit): array
+    {
+        $queryBuilder = $this->createQueryBuilder('mr')
+            ->innerJoin('mr.message', 'm')
+            ->where('mr.status = :status')
+            ->andWhere('m.timeNum >= :since')
+            ->andWhere('m.timeNum <= :until')
+            ->andWhere('mr.amavisReleaseStartedAt IS NULL')
+            ->andWhere(<<<'DQL'
+                NOT EXISTS (
+                    SELECT 1
+                    FROM App\Entity\Log manualSpamLog
+                    WHERE manualSpamLog.mailId = mr.mailId
+                    AND manualSpamLog.action IN (:manualSpamActions)
+                )
+            DQL)
+            ->setParameter('status', MessageStatus::SPAMMED)
+            ->setParameter('since', $since)
+            ->setParameter('until', $until)
+            ->setParameter('manualSpamActions', ['marked as spam', 'marked as spam batch'])
+            ->setMaxResults($limit)
+            ->orderBy('m.timeNum', 'ASC')
+            ->addOrderBy('mr.partitionTag', 'ASC')
+            ->addOrderBy('mr.mailId', 'ASC')
+            ->addOrderBy('mr.rseqnum', 'ASC');
+
+        if ($cursor !== null) {
+            $queryBuilder->andWhere(<<<'DQL'
+                (
+                m.timeNum > :cursorTimeNum
+                OR (m.timeNum = :cursorTimeNum AND mr.partitionTag > :cursorPartitionTag)
+                OR (
+                    m.timeNum = :cursorTimeNum
+                    AND mr.partitionTag = :cursorPartitionTag
+                    AND mr.mailId > :cursorMailId
+                )
+                OR (
+                    m.timeNum = :cursorTimeNum
+                    AND mr.partitionTag = :cursorPartitionTag
+                    AND mr.mailId = :cursorMailId
+                    AND mr.rseqnum > :cursorRseqnum
+                )
+                )
+            DQL)
+                ->setParameter('cursorTimeNum', $cursor['timeNum'])
+                ->setParameter('cursorPartitionTag', $cursor['partitionTag'])
+                ->setParameter('cursorMailId', $cursor['mailId'])
+                ->setParameter('cursorRseqnum', $cursor['rseqnum']);
+        }
+
+        return $queryBuilder->getQuery()->getResult();
+    }
+
+    /**
      * Return all message recipients sent by $senderFrom to $recipientUser.
      *
      * This method is used to fetch the messages sent by a sender who just had

--- a/app/src/Repository/RuleAddressRepository.php
+++ b/app/src/Repository/RuleAddressRepository.php
@@ -3,6 +3,8 @@
 namespace App\Repository;
 
 use App\Entity\RuleAddress;
+use App\Service\RuleAddressService;
+use App\Util\Email;
 use Doctrine\Persistence\ManagerRegistry;
 
 /**
@@ -17,12 +19,13 @@ class RuleAddressRepository extends BaseRepository
 
     public function findOneOrCreateByEmail(string $email, bool $flush = true): RuleAddress
     {
-        $ruleAddress = $this->findOneBy(['email' => $email]);
+        $normalizedEmail = Email::normalize($email);
+        $ruleAddress = $this->findOneBy(['email' => $normalizedEmail]);
 
         if (!$ruleAddress) {
             $ruleAddress = new RuleAddress();
-            $ruleAddress->setEmail($email);
-            $ruleAddress->setPriority(6);
+            $ruleAddress->setEmail($normalizedEmail);
+            $ruleAddress->setPriority(RuleAddressService::computePriority($normalizedEmail));
             $this->save($ruleAddress, $flush);
         }
 

--- a/app/src/Repository/SenderRuleRepository.php
+++ b/app/src/Repository/SenderRuleRepository.php
@@ -253,6 +253,7 @@ class SenderRuleRepository extends BaseRepository
         $senderRule = $this->findOneBy([
             'user' => $recipientUser,
             'senderRuleAddress' => $senderRuleAddress,
+            'priority' => $priority,
         ]);
 
         if (!$senderRule) {

--- a/app/src/Service/MessageService.php
+++ b/app/src/Service/MessageService.php
@@ -13,6 +13,7 @@ use App\Repository\MessageRepository;
 use App\Repository\RuleAddressRepository;
 use App\Repository\SenderRuleRepository;
 use App\Repository\UserRepository;
+use App\Util\Email;
 use Symfony\Component\Messenger\MessageBusInterface;
 
 class MessageService
@@ -43,9 +44,7 @@ class MessageService
             return false;
         }
 
-        // Sender rules are case-insensitive
-        $normalizedEmail = strtolower($senderEmail);
-        $senderRuleAddress = $this->ruleAddressRepository->findOneOrCreateByEmail($normalizedEmail);
+        $senderRuleAddress = $this->ruleAddressRepository->findOneOrCreateByEmail($senderEmail);
 
         $recipient = $messageRecipient->getAddress();
         $userAndAliases = $this->userRepository->findUserAndAliasesByAddress($recipient);
@@ -61,14 +60,14 @@ class MessageService
 
             $messageRecipientsToRelease = $this->messageRecipientRepository->findSentToUserByEmail(
                 $user,
-                strtolower($message->getFromAddr()), // Case-insensitive
+                $message->getFromAddr(),
             );
 
             $domain = $user->getDomain();
             $domainSpamLevel = $domain->getAuthorizedSendersSpamLevel();
 
             foreach ($messageRecipientsToRelease as $messageRecipientToRelease) {
-                $isSameSender = $messageRecipientToRelease->getMessage()->getSenderEmail() === $senderEmail;
+                $isSameSender = $this->hasSameSender($messageRecipientToRelease, $senderEmail);
                 $isSpam = $messageRecipientToRelease->isSpamAtLevel($domainSpamLevel);
                 if (!$isSameSender || $isSpam) {
                     continue;
@@ -121,7 +120,7 @@ class MessageService
         );
 
         foreach ($messageRecipientsToRelease as $messageRecipientToRelease) {
-            $isSameSender = $messageRecipientToRelease->getMessage()->getSenderEmail() === $senderEmail;
+            $isSameSender = $this->hasSameSender($messageRecipientToRelease, $senderEmail);
             $isSpam = $messageRecipientToRelease->isSpamAtLevel($domainSpamLevel);
             if (!$isSameSender || $isSpam) {
                 continue;
@@ -170,7 +169,7 @@ class MessageService
             );
 
             foreach ($messageRecipientsToBan as $messageRecipientToBan) {
-                $isSameSender = $messageRecipientToBan->getMessage()->getSenderEmail() === $senderEmail;
+                $isSameSender = $this->hasSameSender($messageRecipientToBan, $senderEmail);
                 if (
                     !$isSameSender ||
                     $messageRecipientToBan->isVirus() ||
@@ -225,7 +224,7 @@ class MessageService
         );
 
         foreach ($messageRecipientsToBan as $messageRecipientToBan) {
-            $isSameSender = $messageRecipientToBan->getMessage()->getSenderEmail() === $senderEmail;
+            $isSameSender = $this->hasSameSender($messageRecipientToBan, $senderEmail);
             if (
                 !$isSameSender ||
                 $messageRecipientToBan->isVirus() ||
@@ -242,6 +241,14 @@ class MessageService
         $this->messageRepository->save($message);
 
         return true;
+    }
+
+    private function hasSameSender(MessageRecipient $messageRecipient, string $senderEmail): bool
+    {
+        $candidateSenderEmail = $messageRecipient->getMessage()->getSenderEmail();
+
+        return $candidateSenderEmail !== null
+            && Email::normalize($candidateSenderEmail) === Email::normalize($senderEmail);
     }
 
     /**

--- a/app/src/Service/RuleAddressService.php
+++ b/app/src/Service/RuleAddressService.php
@@ -11,7 +11,7 @@ class RuleAddressService
         if (substr(trim($email), 0, 1) == '@') {
             $domain = substr($email, 1);
             if ($domain == '.') {
-                $priority = 0; //in case @.
+                return 0; //in case @.
             }
             $subdomain = explode('.', $domain);
             if (count($subdomain) == "2") {

--- a/app/src/Util/Email.php
+++ b/app/src/Util/Email.php
@@ -45,6 +45,14 @@ class Email
     }
 
     /**
+     * Normalize an email address for case-insensitive comparisons and storage.
+     */
+    public static function normalize(string $email): string
+    {
+        return mb_strtolower($email, 'UTF-8');
+    }
+
+    /**
      * Return a list of email address lookups.
      *
      * The list is built according to how Amavis is looking for emails when
@@ -62,7 +70,7 @@ class Email
      */
     public static function getAddressLookups(string $email): array
     {
-        $normalizedEmail = strtolower($email);
+        $normalizedEmail = self::normalize($email);
         if (!self::validate($normalizedEmail)) {
             return [];
         }

--- a/app/tests/Command/RecoverAuthorizedSpamCommandTest.php
+++ b/app/tests/Command/RecoverAuthorizedSpamCommandTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Tests\Command;
+
+use App\Amavis\MessageStatus;
+use App\Entity\SenderRule;
+use App\Tests\Factory\DomainFactory;
+use App\Tests\Factory\RuleAddressFactory;
+use App\Tests\Factory\SenderRuleFactory;
+use App\Tests\Factory\UserFactory;
+use App\Tests\FactoryHelper;
+use App\Tests\MessageHelper;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+class RecoverAuthorizedSpamCommandTest extends KernelTestCase
+{
+    use Factories;
+    use FactoryHelper;
+    use MessageHelper;
+    use ResetDatabase;
+
+    public function testItReportsThenReleasesFalsePositiveSpam(): void
+    {
+        $domain = DomainFactory::createOne();
+        $recipient = UserFactory::new()->user($domain)->create();
+        $sender = UserFactory::new()->user($domain)->create();
+        [$senderAddress, $recipientAddress] = $this->setupAddresses($sender, $recipient);
+        $message = $this->setupMail($senderAddress, $recipientAddress, status: MessageStatus::SPAMMED);
+        $ruleAddress = RuleAddressFactory::createOne(['email' => $sender->getEmail()]);
+        SenderRuleFactory::createOne([
+            'user' => $recipient,
+            'senderRuleAddress' => $ruleAddress,
+            'wb' => ' ',
+            'priority' => SenderRule::PRIORITY_USER,
+        ]);
+        $messageRecipient = $message->getMessageRecipients()->first();
+        self::assertNotFalse($messageRecipient);
+        $manuallyMarkedMessage = $this->setupMail(
+            $senderAddress,
+            $recipientAddress,
+            status: MessageStatus::SPAMMED,
+        );
+        $manuallyMarkedRecipient = $manuallyMarkedMessage->getMessageRecipients()->first();
+        self::assertNotFalse($manuallyMarkedRecipient);
+        static::getContainer()->get('doctrine.dbal.default_connection')->executeStatement(<<<'SQL'
+            INSERT INTO log (action, mailId, details, created, updated)
+            VALUES ('marked as spam', :mailId, '', NOW(), NOW())
+        SQL, ['mailId' => $manuallyMarkedMessage->getMailId()]);
+
+        $application = new Application(static::createKernel());
+        $command = $application->find('agentj:recover-authorized-spam');
+        $commandTester = new CommandTester($command);
+        $exitCode = $commandTester->execute([
+            '--since' => '1970-01-01T00:00:00+00:00',
+            '--batch-size' => '1',
+        ]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertStringContainsString('1 would be released', $commandTester->getDisplay());
+        $this->refresh($messageRecipient);
+        self::assertSame(MessageStatus::SPAMMED, $messageRecipient->getStatus());
+
+        $commandTester = new CommandTester($command);
+        $exitCode = $commandTester->execute([
+            '--since' => '1970-01-01T00:00:00+00:00',
+            '--release' => true,
+            '--batch-size' => '1',
+        ]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertStringContainsString('1 were queued for release', $commandTester->getDisplay());
+        $this->refresh($messageRecipient);
+        self::assertSame(MessageStatus::AUTHORIZED, $messageRecipient->getStatus());
+        $this->refresh($manuallyMarkedRecipient);
+        self::assertSame(MessageStatus::SPAMMED, $manuallyMarkedRecipient->getStatus());
+    }
+}

--- a/app/tests/Controller/MessageControllerTest.php
+++ b/app/tests/Controller/MessageControllerTest.php
@@ -4,6 +4,7 @@ namespace App\Tests\Controller;
 
 use App\Amavis\MessageStatus;
 use App\Entity\SenderRule;
+use App\Tests\Factory\AddressFactory;
 use App\Tests\Factory\DomainFactory;
 use App\Tests\Factory\MessageFactory;
 use App\Tests\Factory\MessageRecipientFactory;
@@ -393,6 +394,43 @@ class MessageControllerTest extends WebTestCase
             'wb' => ' ', // Mapped from 'accept' by RuleTrait
         ]);
         self::assertCount(1, $aliasRule);
+    }
+
+    public function testAuthorizeMessagesFromSameSenderWithDifferentCase(): void
+    {
+        $client = static::createClient();
+        $domain = DomainFactory::createOne();
+        $recipient = UserFactory::new()->user($domain)->create();
+        $sender = UserFactory::new()->user($domain)->create([
+            'email' => 'AddressCaseTest@' . $domain->getDomain(),
+        ]);
+        $client->loginUser($recipient);
+        [$senderAddress, $recipientAddress] = $this->setupAddresses($sender, $recipient);
+        $lowercaseSenderAddress = AddressFactory::createOne([
+            'domain' => $senderAddress->getDomain(),
+            'partitionTag' => 0,
+            'email' => strtolower($senderAddress->getEmail()),
+        ]);
+        $message = $this->setupMail($senderAddress, $recipientAddress, status: MessageStatus::UNTREATED);
+        $lowercaseMessage = $this->setupMail(
+            $lowercaseSenderAddress,
+            $recipientAddress,
+            status: MessageStatus::UNTREATED,
+        );
+        $messageRecipient = $message->getMessageRecipients()->first();
+        $lowercaseMessageRecipient = $lowercaseMessage->getMessageRecipients()->first();
+        self::assertNotFalse($messageRecipient);
+        self::assertNotFalse($lowercaseMessageRecipient);
+
+        $url = '/message/0/' . $message->getMailId() . '/' . $recipientAddress->getId() . '/authorized';
+        $client->request(Request::METHOD_GET, $url);
+
+        self::assertResponseRedirects('/');
+        self::assertSame(MessageStatus::AUTHORIZED, $messageRecipient->getStatus());
+        self::assertSame(MessageStatus::AUTHORIZED, $lowercaseMessageRecipient->getStatus());
+        self::assertSame(1, RuleAddressFactory::count([
+            'email' => strtolower($senderAddress->getEmail()),
+        ]));
     }
 
     public function testAuthorizedDomainMessage(): void

--- a/app/tests/Migration/RuleAddressNormalizationMigrationTest.php
+++ b/app/tests/Migration/RuleAddressNormalizationMigrationTest.php
@@ -1,0 +1,327 @@
+<?php
+
+namespace App\Tests\Migration;
+
+use App\Tests\Factory\DomainFactory;
+use App\Tests\Factory\GroupFactory;
+use App\Tests\Factory\UserFactory;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Doctrine\Migrations\Exception\AbortMigration;
+use Psr\Log\NullLogger;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+class RuleAddressNormalizationMigrationTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->connection = static::getContainer()->get('doctrine.dbal.default_connection');
+        $this->connection->executeStatement('DROP TEMPORARY TABLE IF EXISTS out_wblist');
+        $this->connection->executeStatement(<<<'SQL'
+            CREATE TEMPORARY TABLE out_wblist (
+                rid INT UNSIGNED NOT NULL,
+                sid INT UNSIGNED NOT NULL,
+                priority INT NOT NULL,
+                group_id INT DEFAULT NULL,
+                wb VARCHAR(10) NOT NULL,
+                datemod DATETIME DEFAULT CURRENT_TIMESTAMP,
+                type INT DEFAULT NULL,
+                PRIMARY KEY (rid, sid, priority)
+            ) ENGINE=InnoDB
+        SQL);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->connection->executeStatement('DROP TEMPORARY TABLE IF EXISTS out_wblist');
+        parent::tearDown();
+    }
+
+    public function testItNormalizesAddressesAndKeepsTheLatestRule(): void
+    {
+        $domain = DomainFactory::createOne();
+        $user = UserFactory::new()->user($domain)->create();
+        $group = GroupFactory::createOne(['domain' => $domain]);
+        $uppercaseId = $this->insertRuleAddress('Sender@Example.org', priority: 99);
+        $lowercaseId = $this->insertRuleAddress('sender@example.org', priority: 42);
+        $this->insertRuleAddress('Unique@Example.org');
+        $this->insertRuleAddress('@.Example.org', priority: 99);
+        $this->connection->executeStatement("UPDATE mailaddr SET priority = 99 WHERE email = BINARY '@.'");
+
+        $this->connection->executeStatement(<<<'SQL'
+            INSERT INTO wblist (rid, sid, group_id, wb, datemod, type, priority)
+            VALUES
+                (:rid, :uppercaseSid, NULL, 'W', '2026-09-09 10:00:00', 3, 100),
+                (:rid, :lowercaseSid, NULL, 'Y', '2026-09-10 10:00:00', 3, 100),
+                (:rid, :uppercaseSid, NULL, 'B', '2026-09-09 10:00:00', 2, 50)
+        SQL, [
+            'rid' => $user->getId(),
+            'uppercaseSid' => $uppercaseId,
+            'lowercaseSid' => $lowercaseId,
+        ]);
+        $this->connection->executeStatement(<<<'SQL'
+            INSERT INTO groups_wblist (group_id, sid, wb)
+            VALUES (:groupId, :uppercaseSid, 'W'), (:groupId, :lowercaseSid, 'Y')
+        SQL, [
+            'groupId' => $group->getId(),
+            'uppercaseSid' => $uppercaseId,
+            'lowercaseSid' => $lowercaseId,
+        ]);
+        $this->connection->executeStatement(<<<'SQL'
+            INSERT INTO out_wblist (rid, sid, group_id, wb, datemod, type, priority)
+            VALUES
+                (:rid, :uppercaseSid, NULL, 'B', '2026-09-11 10:00:00', 4, 100),
+                (:rid, :lowercaseSid, NULL, 'W', '2026-09-10 10:00:00', 5, 100),
+                (:rid, :lowercaseSid, NULL, 'Y', '2026-09-10 10:00:00', 4, 50)
+        SQL, [
+            'rid' => $user->getId(),
+            'uppercaseSid' => $uppercaseId,
+            'lowercaseSid' => $lowercaseId,
+        ]);
+
+        $this->runMigration();
+
+        self::assertSame(1, (int) $this->connection->fetchOne(
+            "SELECT COUNT(*) FROM mailaddr WHERE LOWER(CONVERT(email USING utf8mb4)) = 'sender@example.org'",
+        ));
+        self::assertSame(1, (int) $this->connection->fetchOne(
+            "SELECT COUNT(*) FROM mailaddr WHERE email = BINARY 'unique@example.org'",
+        ));
+        self::assertSame(2, (int) $this->connection->fetchOne(
+            "SELECT priority FROM mailaddr WHERE email = BINARY '@.example.org'",
+        ));
+        self::assertSame(0, (int) $this->connection->fetchOne(
+            "SELECT priority FROM mailaddr WHERE email = BINARY '@.'",
+        ));
+        self::assertSame(2, (int) $this->connection->fetchOne(
+            'SELECT COUNT(*) FROM wblist WHERE rid = ?',
+            [$user->getId()],
+        ));
+        self::assertSame(1, (int) $this->connection->fetchOne(
+            'SELECT COUNT(*) FROM groups_wblist WHERE group_id = ?',
+            [$group->getId()],
+        ));
+        self::assertSame('Y', $this->connection->fetchOne(
+            'SELECT wb FROM wblist WHERE rid = ? AND priority = 100',
+            [$user->getId()],
+        ));
+        self::assertSame('B', $this->connection->fetchOne(
+            'SELECT wb FROM wblist WHERE rid = ? AND priority = 50',
+            [$user->getId()],
+        ));
+        self::assertSame('Y', $this->connection->fetchOne(
+            'SELECT wb FROM groups_wblist WHERE group_id = ?',
+            [$group->getId()],
+        ));
+        self::assertSame(6, (int) $this->connection->fetchOne(
+            "SELECT priority FROM mailaddr WHERE email = BINARY 'sender@example.org'",
+        ));
+        self::assertSame(2, (int) $this->connection->fetchOne(
+            'SELECT COUNT(*) FROM out_wblist WHERE rid = ?',
+            [$user->getId()],
+        ));
+        self::assertSame('B', $this->connection->fetchOne(
+            'SELECT wb FROM out_wblist WHERE rid = ? AND priority = 100',
+            [$user->getId()],
+        ));
+        self::assertSame('Y', $this->connection->fetchOne(
+            'SELECT wb FROM out_wblist WHERE rid = ? AND priority = 50',
+            [$user->getId()],
+        ));
+        $details = $this->conflictLogDetails();
+        self::assertCount(1, $details);
+        self::assertSame('out_wblist', $details[0]['table']);
+        self::assertSame('block', $details[0]['kept_action']);
+        self::assertSame('allow', $details[0]['discarded_action']);
+    }
+
+    public function testItResolvesContradictoryRulesByModificationDate(): void
+    {
+        $domain = DomainFactory::createOne();
+        $user = UserFactory::new()->user($domain)->create();
+        $uppercaseId = $this->insertRuleAddress('Sender@Example.org');
+        $lowercaseId = $this->insertRuleAddress('sender@example.org');
+        $this->connection->executeStatement(<<<'SQL'
+            INSERT INTO wblist (rid, sid, group_id, wb, datemod, type, priority)
+            VALUES
+                (:rid, :uppercaseSid, NULL, 'B', '2026-09-09 10:00:00', 3, 100),
+                (:rid, :lowercaseSid, NULL, 'W', '2026-09-10 10:00:00', 3, 100)
+        SQL, [
+            'rid' => $user->getId(),
+            'uppercaseSid' => $uppercaseId,
+            'lowercaseSid' => $lowercaseId,
+        ]);
+
+        $this->runMigration();
+
+        self::assertSame(1, (int) $this->connection->fetchOne(
+            "SELECT COUNT(*) FROM mailaddr WHERE LOWER(CONVERT(email USING utf8mb4)) = 'sender@example.org'",
+        ));
+        self::assertSame(1, (int) $this->connection->fetchOne(
+            'SELECT COUNT(*) FROM wblist WHERE rid = ?',
+            [$user->getId()],
+        ));
+        self::assertSame('W', $this->connection->fetchOne(
+            'SELECT wb FROM wblist WHERE rid = ?',
+            [$user->getId()],
+        ));
+        $details = $this->conflictLogDetails();
+        self::assertCount(1, $details);
+        self::assertSame('wblist', $details[0]['table']);
+        self::assertSame('allow', $details[0]['kept_action']);
+        self::assertSame('block', $details[0]['discarded_action']);
+    }
+
+    public function testItUsesTheHighestAddressIdWhenModificationDatesAreEqual(): void
+    {
+        $domain = DomainFactory::createOne();
+        $user = UserFactory::new()->user($domain)->create();
+        $group = GroupFactory::createOne(['domain' => $domain]);
+        $lowercaseId = $this->insertRuleAddress('sender@example.org');
+        $uppercaseId = $this->insertRuleAddress('Sender@Example.org');
+        $this->connection->executeStatement(<<<'SQL'
+            INSERT INTO wblist (rid, sid, group_id, wb, datemod, type, priority)
+            VALUES
+                (:rid, :lowercaseSid, NULL, 'W', '2026-09-10 10:00:00', 3, 100),
+                (:rid, :uppercaseSid, :groupId, 'B', '2026-09-10 10:00:00', 4, 100)
+        SQL, [
+            'rid' => $user->getId(),
+            'groupId' => $group->getId(),
+            'lowercaseSid' => $lowercaseId,
+            'uppercaseSid' => $uppercaseId,
+        ]);
+        $this->connection->executeStatement(<<<'SQL'
+            INSERT INTO groups_wblist (group_id, sid, wb)
+            VALUES (:groupId, :lowercaseSid, 'W'), (:groupId, :uppercaseSid, 'B')
+        SQL, [
+            'groupId' => $group->getId(),
+            'lowercaseSid' => $lowercaseId,
+            'uppercaseSid' => $uppercaseId,
+        ]);
+
+        $this->runMigration();
+
+        $rule = $this->connection->fetchAssociative(
+            'SELECT sid, group_id, wb, type FROM wblist WHERE rid = ?',
+            [$user->getId()],
+        );
+        self::assertIsArray($rule);
+        self::assertSame($lowercaseId, (int) $rule['sid']);
+        self::assertSame($group->getId(), (int) $rule['group_id']);
+        self::assertSame('B', $rule['wb']);
+        self::assertSame(4, (int) $rule['type']);
+        $details = $this->conflictLogDetails();
+        self::assertCount(2, $details);
+        self::assertSame(['groups_wblist', 'wblist'], array_column($details, 'table'));
+    }
+
+    public function testItRejectsDatabaseDependentUnicodeNormalization(): void
+    {
+        $this->insertRuleAddress('İ@example.org');
+
+        $this->expectException(AbortMigration::class);
+        $this->expectExceptionMessage('Unicode case folding');
+
+        $this->runMigration();
+    }
+
+    public function testItAcceptsMatchingUnicodeNormalization(): void
+    {
+        $this->insertRuleAddress('é@Example.org');
+
+        $this->runMigration();
+
+        self::assertSame(1, (int) $this->connection->fetchOne(
+            "SELECT COUNT(*) FROM mailaddr WHERE email = BINARY 'é@example.org'",
+        ));
+    }
+
+    public function testGeneratedSqlContainsTheAddressMapBeforeItsUse(): void
+    {
+        $migration = $this->createMigration();
+        $migration->up(new Schema());
+        $statements = array_map(
+            static fn ($query): string => $query->getStatement(),
+            $migration->getSql(),
+        );
+        $sql = implode("\n", $statements);
+
+        self::assertStringContainsString('CREATE TEMPORARY TABLE tmp_rule_address_normalization_map', $sql);
+        self::assertLessThan(
+            strpos($sql, 'CREATE TEMPORARY TABLE tmp_normalized_group_rules'),
+            strpos($sql, 'CREATE TEMPORARY TABLE tmp_rule_address_normalization_map'),
+        );
+    }
+
+    public function testItWorksWhenOutgoingRulesTableIsAbsent(): void
+    {
+        $this->connection->executeStatement('DROP TEMPORARY TABLE out_wblist');
+        $this->insertRuleAddress('Unique@Example.org');
+
+        $this->runMigration();
+
+        self::assertSame(1, (int) $this->connection->fetchOne(
+            "SELECT COUNT(*) FROM mailaddr WHERE email = BINARY 'unique@example.org'",
+        ));
+    }
+
+    private function insertRuleAddress(string $email, int $priority = 6): int
+    {
+        $this->connection->insert('mailaddr', [
+            'priority' => $priority,
+            'email' => $email,
+        ]);
+
+        return (int) $this->connection->fetchOne(
+            'SELECT id FROM mailaddr WHERE email = BINARY ?',
+            [$email],
+        );
+    }
+
+    private function runMigration(): void
+    {
+        $migration = $this->createMigration();
+        $migration->up(new Schema());
+
+        foreach ($migration->getSql() as $query) {
+            $this->connection->executeStatement(
+                $query->getStatement(),
+                $query->getParameters(),
+                $query->getTypes(),
+            );
+        }
+    }
+
+    private function createMigration(): AbstractMigration
+    {
+        require_once dirname(__DIR__, 2) . '/migrations/Version20260910120000.php';
+
+        /** @var class-string<AbstractMigration> $migrationClass */
+        $migrationClass = implode('\\', ['DoctrineMigrations', 'Version20260910120000']);
+        return new $migrationClass($this->connection, new NullLogger());
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function conflictLogDetails(): array
+    {
+        return array_map(
+            static fn (string $details): array => json_decode($details, true, flags: JSON_THROW_ON_ERROR),
+            $this->connection->fetchFirstColumn(<<<'SQL'
+                SELECT details FROM log
+                WHERE action = 'migration sender rule conflict resolved'
+                ORDER BY id
+            SQL),
+        );
+    }
+}

--- a/app/tests/Migration/RuleAddressNormalizationMigrationTest.php
+++ b/app/tests/Migration/RuleAddressNormalizationMigrationTest.php
@@ -70,7 +70,7 @@ class RuleAddressNormalizationMigrationTest extends KernelTestCase
         ]);
         $this->connection->executeStatement(<<<'SQL'
             INSERT INTO groups_wblist (group_id, sid, wb)
-            VALUES (:groupId, :uppercaseSid, 'W'), (:groupId, :lowercaseSid, 'Y')
+            VALUES (:groupId, :uppercaseSid, 'B'), (:groupId, :lowercaseSid, 'W')
         SQL, [
             'groupId' => $group->getId(),
             'uppercaseSid' => $uppercaseId,
@@ -118,7 +118,7 @@ class RuleAddressNormalizationMigrationTest extends KernelTestCase
             'SELECT wb FROM wblist WHERE rid = ? AND priority = 50',
             [$user->getId()],
         ));
-        self::assertSame('Y', $this->connection->fetchOne(
+        self::assertSame('B', $this->connection->fetchOne(
             'SELECT wb FROM groups_wblist WHERE group_id = ?',
             [$group->getId()],
         ));
@@ -133,32 +133,49 @@ class RuleAddressNormalizationMigrationTest extends KernelTestCase
             'SELECT wb FROM out_wblist WHERE rid = ? AND priority = 100',
             [$user->getId()],
         ));
+        self::assertSame($lowercaseId, (int) $this->connection->fetchOne(
+            'SELECT sid FROM out_wblist WHERE rid = ? AND priority = 100',
+            [$user->getId()],
+        ));
         self::assertSame('Y', $this->connection->fetchOne(
             'SELECT wb FROM out_wblist WHERE rid = ? AND priority = 50',
             [$user->getId()],
         ));
         $details = $this->conflictLogDetails();
-        self::assertCount(1, $details);
-        self::assertSame('out_wblist', $details[0]['table']);
-        self::assertSame('block', $details[0]['kept_action']);
-        self::assertSame('allow', $details[0]['discarded_action']);
+        self::assertCount(2, $details);
+        self::assertSame(['groups_wblist', 'out_wblist'], array_column($details, 'table'));
+        foreach ($details as $detail) {
+            self::assertSame($lowercaseId, $detail['kept_sid']);
+            self::assertSame($uppercaseId, $detail['kept_source_sid']);
+            self::assertSame('block', $detail['kept_action']);
+            self::assertSame('allow', $detail['discarded_action']);
+        }
     }
 
     public function testItResolvesContradictoryRulesByModificationDate(): void
     {
         $domain = DomainFactory::createOne();
         $user = UserFactory::new()->user($domain)->create();
-        $uppercaseId = $this->insertRuleAddress('Sender@Example.org');
         $lowercaseId = $this->insertRuleAddress('sender@example.org');
+        $uppercaseId = $this->insertRuleAddress('Sender@Example.org');
+        $group = GroupFactory::createOne(['domain' => $domain]);
         $this->connection->executeStatement(<<<'SQL'
             INSERT INTO wblist (rid, sid, group_id, wb, datemod, type, priority)
             VALUES
-                (:rid, :uppercaseSid, NULL, 'B', '2026-09-09 10:00:00', 3, 100),
-                (:rid, :lowercaseSid, NULL, 'W', '2026-09-10 10:00:00', 3, 100)
+                (:rid, :lowercaseSid, NULL, 'B', '2026-09-10 10:00:00', 3, 100),
+                (:rid, :uppercaseSid, NULL, 'W', '2026-09-09 10:00:00', 3, 100)
         SQL, [
             'rid' => $user->getId(),
             'uppercaseSid' => $uppercaseId,
             'lowercaseSid' => $lowercaseId,
+        ]);
+        $this->connection->executeStatement(<<<'SQL'
+            INSERT INTO groups_wblist (group_id, sid, wb)
+            VALUES (:groupId, :lowercaseSid, 'B'), (:groupId, :uppercaseSid, 'W')
+        SQL, [
+            'groupId' => $group->getId(),
+            'lowercaseSid' => $lowercaseId,
+            'uppercaseSid' => $uppercaseId,
         ]);
 
         $this->runMigration();
@@ -170,15 +187,23 @@ class RuleAddressNormalizationMigrationTest extends KernelTestCase
             'SELECT COUNT(*) FROM wblist WHERE rid = ?',
             [$user->getId()],
         ));
-        self::assertSame('W', $this->connection->fetchOne(
+        self::assertSame('B', $this->connection->fetchOne(
             'SELECT wb FROM wblist WHERE rid = ?',
             [$user->getId()],
         ));
+        self::assertSame('B', $this->connection->fetchOne(
+            'SELECT wb FROM groups_wblist WHERE group_id = ?',
+            [$group->getId()],
+        ));
         $details = $this->conflictLogDetails();
-        self::assertCount(1, $details);
-        self::assertSame('wblist', $details[0]['table']);
-        self::assertSame('allow', $details[0]['kept_action']);
-        self::assertSame('block', $details[0]['discarded_action']);
+        self::assertCount(2, $details);
+        self::assertSame(['groups_wblist', 'wblist'], array_column($details, 'table'));
+        foreach ($details as $detail) {
+            self::assertSame($lowercaseId, $detail['kept_sid']);
+            self::assertSame($lowercaseId, $detail['kept_source_sid']);
+            self::assertSame('block', $detail['kept_action']);
+            self::assertSame('allow', $detail['discarded_action']);
+        }
     }
 
     public function testItUsesTheHighestAddressIdWhenModificationDatesAreEqual(): void
@@ -201,7 +226,7 @@ class RuleAddressNormalizationMigrationTest extends KernelTestCase
         ]);
         $this->connection->executeStatement(<<<'SQL'
             INSERT INTO groups_wblist (group_id, sid, wb)
-            VALUES (:groupId, :lowercaseSid, 'W'), (:groupId, :uppercaseSid, 'B')
+            VALUES (:groupId, :lowercaseSid, 'W'), (:groupId, :uppercaseSid, 'Y')
         SQL, [
             'groupId' => $group->getId(),
             'lowercaseSid' => $lowercaseId,
@@ -219,9 +244,13 @@ class RuleAddressNormalizationMigrationTest extends KernelTestCase
         self::assertSame($group->getId(), (int) $rule['group_id']);
         self::assertSame('B', $rule['wb']);
         self::assertSame(4, (int) $rule['type']);
+        self::assertSame('Y', $this->connection->fetchOne(
+            'SELECT wb FROM groups_wblist WHERE group_id = ?',
+            [$group->getId()],
+        ));
         $details = $this->conflictLogDetails();
-        self::assertCount(2, $details);
-        self::assertSame(['groups_wblist', 'wblist'], array_column($details, 'table'));
+        self::assertCount(1, $details);
+        self::assertSame('wblist', $details[0]['table']);
     }
 
     public function testItRejectsDatabaseDependentUnicodeNormalization(): void

--- a/app/tests/Repository/RuleAddressRepositoryTest.php
+++ b/app/tests/Repository/RuleAddressRepositoryTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Tests\Repository;
+
+use App\Repository\RuleAddressRepository;
+use App\Tests\Factory\RuleAddressFactory;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+class RuleAddressRepositoryTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    public function testFindOneOrCreateNormalizesAndReusesRuleAddress(): void
+    {
+        self::bootKernel();
+        $repository = static::getContainer()->get(RuleAddressRepository::class);
+
+        $first = $repository->findOneOrCreateByEmail('Sender@Example.ORG');
+        $second = $repository->findOneOrCreateByEmail('sender@example.org');
+
+        self::assertSame($first->getId(), $second->getId());
+        self::assertSame('sender@example.org', $first->getEmail());
+        self::assertSame(6, $first->getPriority());
+        self::assertSame(1, RuleAddressFactory::count(['email' => 'sender@example.org']));
+    }
+
+    public function testFindOneOrCreateComputesDomainPriority(): void
+    {
+        self::bootKernel();
+        $repository = static::getContainer()->get(RuleAddressRepository::class);
+
+        $ruleAddress = $repository->findOneOrCreateByEmail('@.Example.ORG');
+
+        self::assertSame('@.example.org', $ruleAddress->getEmail());
+        self::assertSame(2, $ruleAddress->getPriority());
+    }
+
+    public function testFindOneOrCreateComputesRootPriority(): void
+    {
+        self::bootKernel();
+        $repository = static::getContainer()->get(RuleAddressRepository::class);
+
+        $ruleAddress = $repository->findOneOrCreateByEmail('@.');
+
+        self::assertSame(0, $ruleAddress->getPriority());
+    }
+}

--- a/app/tests/Repository/SenderRuleRepositoryTest.php
+++ b/app/tests/Repository/SenderRuleRepositoryTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Tests\Repository;
+
+use App\Entity\SenderRule;
+use App\Repository\SenderRuleRepository;
+use App\Tests\Factory\AddressFactory;
+use App\Tests\Factory\DomainFactory;
+use App\Tests\Factory\RuleAddressFactory;
+use App\Tests\Factory\SenderRuleFactory;
+use App\Tests\Factory\UserFactory;
+use App\Util\Url;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+class SenderRuleRepositoryTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    public function testItMatchesSenderRulesRegardlessOfMessageCase(): void
+    {
+        self::bootKernel();
+        $domain = DomainFactory::createOne();
+        $recipient = UserFactory::new()->user($domain)->create();
+        $recipientAddress = AddressFactory::createOne([
+            'partitionTag' => 0,
+            'email' => $recipient->getEmail(),
+            'domain' => Url::reverseDomainName($domain->getDomain()),
+        ]);
+        $ruleAddress = RuleAddressFactory::createOne([
+            'email' => 'sender@example.org',
+            'priority' => 6,
+        ]);
+        SenderRuleFactory::createOne([
+            'user' => $recipient,
+            'senderRuleAddress' => $ruleAddress,
+            'wb' => ' ',
+            'priority' => SenderRule::PRIORITY_USER,
+        ]);
+
+        $repository = static::getContainer()->get(SenderRuleRepository::class);
+
+        self::assertTrue($repository->isSenderAuthorizedByRecipient('Sender@Example.ORG', $recipientAddress));
+    }
+}

--- a/app/tests/Util/EmailTest.php
+++ b/app/tests/Util/EmailTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Tests\Util;
+
+use App\Util\Email;
+use PHPUnit\Framework\TestCase;
+
+class EmailTest extends TestCase
+{
+    public function testNormalizeEmailAddress(): void
+    {
+        self::assertSame('sender@example.org', Email::normalize('Sender@Example.ORG'));
+    }
+
+    public function testAddressLookupsAreNormalized(): void
+    {
+        self::assertSame([
+            'user@sub.example.com',
+            '@sub.example.com',
+            '@.sub.example.com',
+            '@.example.com',
+            '@.com',
+            '@.',
+        ], Email::getAddressLookups('User@Sub.Example.COM'));
+    }
+}


### PR DESCRIPTION
## Related issue(s)

https://github.com/Probesys/agentj/issues/638

## How to test manually

1. Install or check out an AgentJ version earlier than 2.7.
2. Create an accepted or allowed sender rule containing uppercase characters, such as `Sender@Example.org`.
3. Optionally create another rule for `sender@example.org` with a different action and a more recent `datemod`.
4. Upgrade to this branch and run the database migrations.
5. Verify that the sender addresses are stored in lowercase and that no case-insensitive duplicates remain.
6. If contradictory rules existed, verify that the rule with the newest `datemod` was retained.
7. Verify the migration audit entry:

   ```sql
   SELECT created, details
   FROM log
   WHERE action = 'migration sender rule conflict resolved'
   ORDER BY created DESC;
 8. Receive a message from the same sender using different casing.
 9. Verify that the existing sender rule is matched and that the authorized-sender spam threshold is applied.
10. To test recovery, identify a SPAMMED message whose score is below or equal to the authorized-sender threshold.
11. Run the recovery command in report-only mode:
./scripts/console agentj:recover-authorized-spam \
    --since="2026-09-01T00:00:00+02:00" \
    -vv
12. Verify that the command reports the affected message without modifying it.
13. Mark another message explicitly as spam through AgentJ and verify that it is not reported as recoverable.
14. Release the reported messages:
./scripts/console agentj:recover-authorized-spam \
    --since="2026-09-01T00:00:00+02:00" \
    --release \
    -vv
15. Verify that the recoverable messages are queued for release while explicitly marked spam messages remain unchanged.

## Reviewer checklist
<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [ ] Code is manually tested
- [ ] Interface works on both mobiles and big screens
- [ ] Interface works on both Firefox and Chrome
- [ ] Tests are up to date
- [ ] Documentation is up to date
- [ ] Pull request has been reviewed and approved
